### PR TITLE
Add camera synchronization.

### DIFF
--- a/Assets/Scenes/PlayerMouseKeyboard.unity
+++ b/Assets/Scenes/PlayerMouseKeyboard.unity
@@ -342,6 +342,7 @@ GameObject:
   - component: {fileID: 695650940}
   - component: {fileID: 695650939}
   - component: {fileID: 695650938}
+  - component: {fileID: 695650942}
   m_Layer: 0
   m_Name: App
   m_TagString: Untagged
@@ -454,6 +455,19 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8e8b04a25ef33ce75848e2abc2c2c60c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &695650942
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 695650929}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b93bb6d3f5d41565882ab91db60969f4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _camera: {fileID: 389742605}
 --- !u!1001 &712471222
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/CameraTransformHandler.cs
+++ b/Assets/Scripts/CameraTransformHandler.cs
@@ -1,0 +1,17 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CameraTransformHandler : MonoBehaviour, IKeyframeMessageConsumer
+{
+    [Tooltip("Camera to manipulate upon receiving server updates.")]
+    public Camera _camera;
+
+    public void ProcessMessage(Message message)
+    {
+        if (message.camera?.translation?.Count == 3 && message.camera?.rotation?.Count == 4) {
+            Camera.main.transform.position = CoordinateSystem.ToUnityVector(message.camera.translation);
+            Camera.main.transform.rotation = CoordinateSystem.ToUnityQuaternion(message.camera.rotation);
+        }
+    }
+}

--- a/Assets/Scripts/CameraTransformHandler.cs.meta
+++ b/Assets/Scripts/CameraTransformHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b93bb6d3f5d41565882ab91db60969f4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ClientState.cs
+++ b/Assets/Scripts/ClientState.cs
@@ -33,7 +33,7 @@ public class PoseData
     public void FromGameObject(GameObject gameObject)
     {
         position = CoordinateSystem.ToHabitatVector(gameObject.transform.position).ToArray();
-        rotation = CoordinateSystem.ToHabitatQuaternion(gameObject.transform.rotation).ToArray();
+        rotation = CoordinateSystem.ToHabitatQuaternion3DModel(gameObject.transform.rotation).ToArray();
     }
 }
 

--- a/Assets/Scripts/CoordinateSystem.cs
+++ b/Assets/Scripts/CoordinateSystem.cs
@@ -6,12 +6,18 @@ using UnityEngine;
 /// 
 /// Habitat: X-Left, Y-Up, Z-Back
 /// Unity:   X-Left, Y-Up, Z-Forward
+/// 
+/// Beware that because of the change in handedness, the Unity asset pipeline bakes the z-axis flip into 3D models.
+/// See ToUnityQuaternion3DModel() and ToHabitatQuaternion3DModel().
 /// </summary>
 public static class CoordinateSystem
 {
-    private static Quaternion _defaultRotation = Quaternion.Euler(0, 180, 0);
-    private static Quaternion _invDefaultRotation = Quaternion.Inverse(_defaultRotation);
+    private static readonly Quaternion _3dModelRotationCorrection = Quaternion.Euler(0, 180, 0);
+    private static readonly Quaternion _inv3dModelRotationCorrection = Quaternion.Inverse(_3dModelRotationCorrection);
 
+    /// <summary>
+    /// Convert a Habitat vector into Unity's coordinate system.
+    /// </summary>
     public static Vector3 ToUnityVector(float x, float y, float z)
     {
         return new Vector3(
@@ -21,6 +27,9 @@ public static class CoordinateSystem
         );
     }
 
+    /// <summary>
+    /// Convert a Habitat vector into Unity's coordinate system.
+    /// </summary>
     public static Vector3 ToUnityVector(List<float> translation)
     {
         return new Vector3(
@@ -29,8 +38,26 @@ public static class CoordinateSystem
             -translation[2]
         );
     }
-
+    
+    /// <summary>
+    /// Convert a Habitat quaternion into Unity's coordinate system.
+    /// Beware: the Unity asset pipeline bakes transforms into 3D models. Use ToUnityQuaternion3DModel() to rotate models.
+    /// </summary>
     public static Quaternion ToUnityQuaternion(List<float> rotation)
+    {
+        return new Quaternion(
+            rotation[1],
+            rotation[2],
+            -rotation[3],
+            -rotation[0]
+        );
+    }
+
+    /// <summary>
+    /// Convert a Habitat quaternion into Unity's coordinate system, taking into account 3D model baked transformations.
+    /// 3D models are pre-processed to handle the change in handedness (avoids negative scaling on the z-axis).
+    /// </summary>
+    public static Quaternion ToUnityQuaternion3DModel(List<float> rotation)
     {
         Quaternion newRot = new Quaternion(
             rotation[1],
@@ -39,10 +66,13 @@ public static class CoordinateSystem
             rotation[0]
         );
 
-        newRot = _defaultRotation * newRot;
+        newRot = _3dModelRotationCorrection * newRot;
         return newRot;
     }
 
+    /// <summary>
+    /// Convert a Unity vector into Habitat's coordinate system.
+    /// </summary>
     public static List<float> ToHabitatVector(Vector3 translation)
     {
         return new List<float>
@@ -53,9 +83,30 @@ public static class CoordinateSystem
         };
     }
 
+    /// <summary>
+    /// Convert a Unity quaternion into Habitat's coordinate system.
+    /// Beware: the Unity asset pipeline bakes transforms into 3D models. Use ToHabitatQuaternion3DModel() to rotate models.
+    /// </summary>
     public static List<float> ToHabitatQuaternion(Quaternion rotation)
     {
-        Quaternion convertedRotation = _invDefaultRotation * rotation;
+        Quaternion convertedRotation = _inv3dModelRotationCorrection * rotation;
+
+        return new List<float>
+        {
+            -convertedRotation.w,
+            convertedRotation.x,
+            convertedRotation.y,
+            -convertedRotation.z
+        };
+    }
+
+    /// <summary>
+    /// Convert a Unity quaternion into Habitat's coordinate system, taking into account 3D model baked transformations.
+    /// 3D models are pre-processed to handle the change in handedness (avoids negative scaling on the z-axis).
+    /// </summary>
+    public static List<float> ToHabitatQuaternion3DModel(Quaternion rotation)
+    {
+        Quaternion convertedRotation = _inv3dModelRotationCorrection * rotation;
 
         return new List<float>
         {

--- a/Assets/Scripts/GfxReplayPlayer.cs
+++ b/Assets/Scripts/GfxReplayPlayer.cs
@@ -107,7 +107,7 @@ public class GfxReplayPlayer : MonoBehaviour
                     GameObject instance = _instanceDictionary[update.instanceKey];
 
                     Vector3 translation = CoordinateSystem.ToUnityVector(update.state.absTransform.translation);
-                    Quaternion rotation = CoordinateSystem.ToUnityQuaternion(update.state.absTransform.rotation);
+                    Quaternion rotation = CoordinateSystem.ToUnityQuaternion3DModel(update.state.absTransform.rotation);
 
                     instance.transform.position = translation;
                     instance.transform.rotation = rotation;
@@ -127,7 +127,7 @@ public class GfxReplayPlayer : MonoBehaviour
                     GameObject instance = _instanceDictionary[update.instanceKey];
 
                     Vector3 newTranslation = CoordinateSystem.ToUnityVector(update.state.absTransform.translation);
-                    Quaternion newRotation = CoordinateSystem.ToUnityQuaternion(update.state.absTransform.rotation);
+                    Quaternion newRotation = CoordinateSystem.ToUnityQuaternion3DModel(update.state.absTransform.rotation);
 
                     // Check if the instance is at the origin
                     if (instance.transform.position == Vector3.zero)

--- a/Assets/Scripts/Keyframe.cs
+++ b/Assets/Scripts/Keyframe.cs
@@ -39,6 +39,13 @@ public class Frame
 }
 
 [Serializable]
+public class AbsTransform
+{
+    public List<float> translation;
+    public List<float> rotation;
+}
+
+[Serializable]
 public class CreationItem
 {
     public int instanceKey;
@@ -63,13 +70,6 @@ public class StateUpdate
     {
         public AbsTransform absTransform;
         public int semanticId;
-
-        [Serializable]
-        public class AbsTransform
-        {
-            public List<float> translation;
-            public List<float> rotation;
-        }
     }
 }
 
@@ -85,6 +85,8 @@ public class Message
     public List<float> navmeshVertices;
 
     public string textMessage;
+
+    public AbsTransform camera;
 }
 
 [Serializable]


### PR DESCRIPTION
This adds camera synchronization to `PlayerMouseKeyboard`.

Beware that because of the change in handedness, the Unity asset pipeline bakes the z-axis flip into 3D models. Because of this, the old `ToUnityQuaternion` function was only applicable to 3D models. It was renamed to `ToUnityQuaternion3DModel`.