### PR TITLE
Highlight ring colors, billboarding and polishing.

### DIFF
--- a/Assets/Scripts/AppConfig.cs
+++ b/Assets/Scripts/AppConfig.cs
@@ -11,8 +11,8 @@ public class AppConfig : ScriptableObject
     [Tooltip("Line segment count composing the highlight circles.\nThis value cannot be changed during runtime.")]
     public int highlightCircleResolution = 32;
 
-    [Tooltip("Vertex color of the highlight lines.")]
-    public Color highlightColor = Color.white;
+    [Tooltip("Default vertex color of the highlight lines.")]
+    public Color highlightDefaultColor = Color.white;
 
     [Tooltip("Materials used to shade the highlight circles.")]
     public Material[] highlightMaterials;

--- a/Assets/Scripts/CoordinateSystem.cs
+++ b/Assets/Scripts/CoordinateSystem.cs
@@ -30,7 +30,7 @@ public static class CoordinateSystem
     /// <summary>
     /// Convert a Habitat vector into Unity's coordinate system.
     /// </summary>
-    public static Vector3 ToUnityVector(List<float> translation)
+    public static Vector3 ToUnityVector(IList<float> translation)
     {
         return new Vector3(
             translation[0],
@@ -43,7 +43,7 @@ public static class CoordinateSystem
     /// Convert a Habitat quaternion into Unity's coordinate system.
     /// Beware: the Unity asset pipeline bakes transforms into 3D models. Use ToUnityQuaternion3DModel() to rotate models.
     /// </summary>
-    public static Quaternion ToUnityQuaternion(List<float> rotation)
+    public static Quaternion ToUnityQuaternion(IList<float> rotation)
     {
         return new Quaternion(
             rotation[1],
@@ -57,7 +57,7 @@ public static class CoordinateSystem
     /// Convert a Habitat quaternion into Unity's coordinate system, taking into account 3D model baked transformations.
     /// 3D models are pre-processed to handle the change in handedness (avoids negative scaling on the z-axis).
     /// </summary>
-    public static Quaternion ToUnityQuaternion3DModel(List<float> rotation)
+    public static Quaternion ToUnityQuaternion3DModel(IList<float> rotation)
     {
         Quaternion newRot = new Quaternion(
             rotation[1],

--- a/Assets/Scripts/HighlightManager.cs
+++ b/Assets/Scripts/HighlightManager.cs
@@ -1,5 +1,6 @@
 using System;
 using UnityEngine;
+using UnityEngine.Assertions;
 
 public class HighlightManager : IKeyframeMessageConsumer
 {
@@ -68,8 +69,9 @@ public class HighlightManager : IKeyframeMessageConsumer
                 lineRenderer.enabled = true;
 
                 Color color = _config.highlightDefaultColor;
-                if (msg.c != null && msg.c.Length == 4)
+                if (msg.c != null && msg.c.Length > 0)                
                 {
+                    Assert.AreEqual(msg.c.Length, 4, $"Invalid highlight color format. Expected 4 ints, got {msg.c.Length}.");
                     color.r = (float)msg.c[0] / 255.0f;
                     color.g = (float)msg.c[1] / 255.0f;
                     color.b = (float)msg.c[2] / 255.0f;

--- a/Assets/Scripts/HighlightManager.cs
+++ b/Assets/Scripts/HighlightManager.cs
@@ -33,8 +33,8 @@ public class HighlightManager : IKeyframeMessageConsumer
             lineRenderer.enabled = false;
             lineRenderer.loop = true;
             lineRenderer.useWorldSpace = false;
-            lineRenderer.startColor = config.highlightColor;
-            lineRenderer.endColor = config.highlightColor;
+            lineRenderer.startColor = config.highlightDefaultColor;
+            lineRenderer.endColor = config.highlightDefaultColor;
             lineRenderer.startWidth = config.highlightWidth;
             lineRenderer.endWidth = config.highlightWidth;
             lineRenderer.materials = config.highlightMaterials;
@@ -63,18 +63,37 @@ public class HighlightManager : IKeyframeMessageConsumer
             _activeHighlightCount = Math.Min(highlightsMessage.Length, _highlightPool.Length);
             for (int i = 0; i < _activeHighlightCount; ++i)
             {
-                var highlight = _highlightPool[i];
-                highlight.enabled = true;
+                Highlight msg = highlightsMessage[i];
+                var lineRenderer = _highlightPool[i];
+                lineRenderer.enabled = true;
+
+                Color color = _config.highlightDefaultColor;
+                if (msg.c != null && msg.c.Length == 4)
+                {
+                    color.r = (float)msg.c[0] / 255.0f;
+                    color.g = (float)msg.c[1] / 255.0f;
+                    color.b = (float)msg.c[2] / 255.0f;
+                    color.a = (float)msg.c[3] / 255.0f;
+                }
+                lineRenderer.startColor = color;
+                lineRenderer.endColor = color;
 
                 // Apply translation from message
-                Vector3 center = CoordinateSystem.ToUnityVector(highlightsMessage[i].t);
-                highlight.transform.position = center;
+                Vector3 center = CoordinateSystem.ToUnityVector(msg.t);
+                lineRenderer.transform.position = center;
 
                 // Billboarding
-                highlight.transform.LookAt(_camera.transform);
+                if (msg.b == 1)
+                {
+                    lineRenderer.transform.LookAt(_camera.transform);
+                }
+                else
+                {
+                    lineRenderer.transform.LookAt(center + Vector3.up);
+                }
 
                 // Apply radius from message using scale
-                highlight.transform.localScale = highlightsMessage[i].r * Vector3.one;
+                lineRenderer.transform.localScale = highlightsMessage[i].r * Vector3.one;
             }
         }
     }

--- a/Assets/Scripts/Keyframe.cs
+++ b/Assets/Scripts/Keyframe.cs
@@ -121,6 +121,9 @@ public class Message
 [Serializable]
 public class Highlight
 {
-    public List<float> t;
-    public float r;
+    // Note: short variable names and values to reduce json data size.
+    public float[] t; // Position
+    public float r; // Radius
+    public int b = 0; // 0 = Face-up, 1 = Billboard (face camera)
+    public int[] c; // Color, RGBA, 0-255
 }

--- a/Assets/Settings/Project Configuration/ObjectHighlight.mat
+++ b/Assets/Settings/Project Configuration/ObjectHighlight.mat
@@ -136,7 +136,7 @@ Material:
     - _ZWrite: 1
     m_Colors:
     - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
-    - _Color: {r: 0, g: 0.9500499, b: 1, a: 1}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
   m_BuildTextureStacks: []

--- a/Assets/Settings/Project Configuration/ObjectHighlightOccluded.mat
+++ b/Assets/Settings/Project Configuration/ObjectHighlightOccluded.mat
@@ -136,7 +136,7 @@ Material:
     - _ZWrite: 1
     m_Colors:
     - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
-    - _Color: {r: 0, g: 0.6603774, b: 0.6603774, a: 0.42745098}
+    - _Color: {r: 0.6981132, g: 0.6981132, b: 0.6981132, a: 0.42745098}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
   m_BuildTextureStacks: []


### PR DESCRIPTION
This changeset ports [this upstream demo commit](https://github.com/eundersander/siro_hitl_unity_client/commit/1ec94c7c17579fa6d038b14740217baa53fd79b2) to `main`.

* Add support for server-driven highlight ring color and billboarding state.
* Changes the default highlight color.
* Makes `CoordiniateSystem` functions accept `IList` instead of `List` to allow for arrays.