### PR TITLE
Port upstream networking features to main.

### DIFF
--- a/Assets/Scripts/AppMouseKeyboard.cs
+++ b/Assets/Scripts/AppMouseKeyboard.cs
@@ -27,6 +27,7 @@ public class AppMouseKeyboard : MonoBehaviour
     [SerializeField] private GameObject _offlineIcon;
 
     // IKeyframeMessageConsumers
+    ServerKeyframeIdHandler _serverKeyframeIdHandler;
     HighlightManager _highlightManager;
     LoadingEffectHandler _loadingEffectHandler;
     CameraTransformHandler _cameraTransformHandler;
@@ -45,11 +46,13 @@ public class AppMouseKeyboard : MonoBehaviour
     protected void Awake()
     {
         // Initialize IKeyframeMessageConsumers.
+        _serverKeyframeIdHandler = new ServerKeyframeIdHandler();
         _highlightManager = new HighlightManager(_appConfig, _camera);
         _loadingEffectHandler = new LoadingEffectHandler();
         _cameraTransformHandler = new CameraTransformHandler(_camera);
         var keyframeMessageConsumers = new IKeyframeMessageConsumer[]
         {
+            _serverKeyframeIdHandler,
             _highlightManager,
             _loadingEffectHandler,
             _cameraTransformHandler,
@@ -67,7 +70,7 @@ public class AppMouseKeyboard : MonoBehaviour
         // Initialize application state.
         _configLoader = new ConfigLoader(_defaultServerLocations);
         _gfxReplayPlayer = new GfxReplayPlayer(keyframeMessageConsumers);
-        _networkClient = new NetworkClient(_gfxReplayPlayer, _configLoader, clientStateProducers);
+        _networkClient = new NetworkClient(_gfxReplayPlayer, _configLoader, clientStateProducers, _serverKeyframeIdHandler);
         _onlineStatusDisplayHandler = new OnlineStatusDisplayHandler(_offlineIcon, _camera);
         _replayFileLoader = new ReplayFileLoader(_gfxReplayPlayer, _testKeyframe);
     }

--- a/Assets/Scripts/AppVR.cs
+++ b/Assets/Scripts/AppVR.cs
@@ -49,6 +49,7 @@ public class AppVR : MonoBehaviour
     
 
     // IKeyframeMessageConsumers
+    ServerKeyframeIdHandler _serverKeyframeIdHandler;
     AvatarPositionHandler _avatarPositionHandler;
     HighlightManager _highlightManager;
     LoadingEffectHandler _loadingEffectHandler;
@@ -75,6 +76,7 @@ public class AppVR : MonoBehaviour
         _collisionFloor = new CollisionFloor();
 
         // Initialize IKeyframeMessageConsumers.
+        _serverKeyframeIdHandler = new ServerKeyframeIdHandler();
         _avatarPositionHandler = new AvatarPositionHandler(_camera.gameObject, _xrOrigin);
         _highlightManager = new HighlightManager(_appConfig, _camera);
         _loadingEffectHandler = new LoadingEffectHandler();
@@ -82,6 +84,7 @@ public class AppVR : MonoBehaviour
         _navmeshHelper = new NavmeshHelper();
         var keyframeMessageConsumers = new IKeyframeMessageConsumer[]
         {
+            _serverKeyframeIdHandler,
             _avatarPositionHandler,
             _highlightManager,
             _loadingEffectHandler,
@@ -101,7 +104,7 @@ public class AppVR : MonoBehaviour
         // Initialize application state.
         _configLoader = new ConfigLoader(_defaultServerLocations);
         _gfxReplayPlayer = new GfxReplayPlayer(keyframeMessageConsumers);
-        _networkClient = new NetworkClient(_gfxReplayPlayer, _configLoader, clientStateProducers);
+        _networkClient = new NetworkClient(_gfxReplayPlayer, _configLoader, clientStateProducers, _serverKeyframeIdHandler);
         _onlineStatusDisplayHandler = new OnlineStatusDisplayHandler(_offlineIcon, _camera);
         _replayFileLoader = new ReplayFileLoader(_gfxReplayPlayer, _testKeyframe);
     }

--- a/Assets/Scripts/ClientState.cs
+++ b/Assets/Scripts/ClientState.cs
@@ -10,6 +10,7 @@ public class ClientState
     public ButtonInputData input;
     public MouseInputData mouse;
     public Dictionary<string, string> connection_params_dict;
+    public int? recentServerKeyframeId = null;
 }
 
 [Serializable]

--- a/Assets/Scripts/ConnectionParameters.cs
+++ b/Assets/Scripts/ConnectionParameters.cs
@@ -65,8 +65,8 @@ public static class ConnectionParameters
     }
 
     /// <summary>
-    /// Tries to parse a port string.
-    /// Valid if the port can be parsed into an integer between 0 and 65535 inclusively.
+    /// Try to parse a port string.
+    /// Checks if the port can be parsed into an integer between 0 and 65535 inclusively.
     /// </summary>
     /// <param name="portString">String to parse.</param>
     /// <param name="result">Output port.</param>
@@ -86,8 +86,8 @@ public static class ConnectionParameters
 
     /// <summary>
     /// Get a valid server port range from query parameters.
-    /// The 'server_port_range' parameter defines two ports defines by a '-'.
-    /// The 'server_port' defines a single port.
+    /// The 'server_port_range' parameter defines two ports, e.g. "server_port_range=2222-3333".
+    /// The 'server_port' defines a single port, e.g. "server_port=2222".
     /// If both parameters are defined, 'server_port_range' has priority over 'server_port'.
     /// </summary>
     /// <param name="queryParams">See GetConnectionParameters().</param>
@@ -96,6 +96,7 @@ public static class ConnectionParameters
     {
         if (queryParams == null) return null;
 
+        // Parse "server_port_range".
         if (queryParams.TryGetValue("server_port_range", out string serverPortRangeString))
         {
             string[] parts = serverPortRangeString.Split('-');
@@ -114,9 +115,10 @@ public static class ConnectionParameters
             }
             else
             {
-                Debug.LogError($"Invalid server_port_range: '{serverPortRangeString}'");
+                Debug.LogError($"Invalid server_port_range: '{serverPortRangeString}'. Expected format: 'server_port_range=2222-3333'.");
             }
         }
+        // Parse "server_port".
         else if (queryParams.TryGetValue("server_port", out string serverPortString))
         {
             if (TryParsePortString(serverPortString, out int port))
@@ -125,7 +127,7 @@ public static class ConnectionParameters
             }
             else
             {
-                Debug.LogError($"Invalid server_port: '{serverPortString}'");
+                Debug.LogError($"Invalid server_port: '{serverPortString}'. Expected format: 'server_port=2222'.");
             }
         }
 

--- a/Assets/Scripts/ConnectionParameters.cs
+++ b/Assets/Scripts/ConnectionParameters.cs
@@ -65,21 +65,63 @@ public static class ConnectionParameters
     }
 
     /// <summary>
-    /// Get a valid server port from query parameters.
+    /// Tries to parse a port string.
+    /// Valid if the port can be parsed into an integer between 0 and 65535 inclusively.
+    /// </summary>
+    /// <param name="portString">String to parse.</param>
+    /// <param name="result">Output port.</param>
+    /// <returns>True if the string could be parsed.</returns>
+    public static bool TryParsePortString(string portString, out int result)
+    {
+        result = 0;
+        if (int.TryParse(portString, out int port) &&
+            port >= 0 &&
+            port <= 65535)
+        {
+            result = port;
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Get a valid server port range from query parameters.
+    /// The 'server_port_range' parameter defines two ports defines by a '-'.
+    /// The 'server_port' defines a single port.
+    /// If both parameters are defined, 'server_port_range' has priority over 'server_port'.
     /// </summary>
     /// <param name="queryParams">See GetConnectionParameters().</param>
-    /// <returns>Port int. Returns null if the input does not contain a valid port.</returns>
-    public static int? GetServerPort(Dictionary<string, string> queryParams)
+    /// <returns>Port range. Always in increasing order. Returns null if the input does not contain a valid port.</returns>
+    public static (int startPort, int endPort)? GetServerPortRange(Dictionary<string, string> queryParams)
     {
         if (queryParams == null) return null;
 
-        if (queryParams.TryGetValue("server_port", out string serverPortString))
+        if (queryParams.TryGetValue("server_port_range", out string serverPortRangeString))
         {
-            if (int.TryParse(serverPortString, out int port) &&
-                port >= 0 &&
-                port <= 65535)
+            string[] parts = serverPortRangeString.Split('-');
+            if (parts.Length == 2 &&
+                TryParsePortString(parts[0], out int startPort) &&
+                TryParsePortString(parts[1], out int endPort))
             {
-                return port;
+                if (startPort <= endPort)
+                {
+                    return (startPort, endPort);
+                }
+                else
+                {
+                    return (endPort, startPort);
+                }
+            }
+            else
+            {
+                Debug.LogError($"Invalid server_port_range: '{serverPortRangeString}'");
+            }
+        }
+        else if (queryParams.TryGetValue("server_port", out string serverPortString))
+        {
+            if (TryParsePortString(serverPortString, out int port))
+            {
+                return (port, port);
             }
             else
             {

--- a/Assets/Scripts/Keyframe.cs
+++ b/Assets/Scripts/Keyframe.cs
@@ -116,6 +116,8 @@ public class Message
     public string textMessage;
 
     public AbsTransform camera;
+
+    public int serverKeyframeId;
 }
 
 [Serializable]

--- a/Assets/Scripts/NetworkClient.cs
+++ b/Assets/Scripts/NetworkClient.cs
@@ -202,6 +202,8 @@ public class NetworkClient : IUpdatable
 
                     if (_disconnectReason == "")
                     {
+                        // If there's only one server URL, let's wait 5s (avoid hammering more often than that).
+                        // If there's multiple server URLs, let's try them more quickly (wait only 2s).
                         _delayReconnect = _serverURLs.Count == 1 ? 5.0f : 2.0f;
                         _disconnectReason = "Unable to reach server!";
                     }
@@ -271,7 +273,7 @@ public class NetworkClient : IUpdatable
         websocket.OnMessage += (bytes) =>
         {
             if (_recentConnectionMessageCount == 0) {
-                // delete all old instances on reconnect
+                // Delete all old instances upon receiving the first keyframe.
                 _player.DeleteAllInstancesFromKeyframes();
             }
 

--- a/Assets/Scripts/NetworkClient.cs
+++ b/Assets/Scripts/NetworkClient.cs
@@ -232,8 +232,11 @@ public class NetworkClient : IUpdatable
             Debug.Log("Connected to: " + url);
             _recentConnectionMessageCount = 0;
 
+            // Reset the server keyframe ID to avoid leaking ID from a previous session
+            _serverKeyframeIdHandler.Reset();
+
             // send connection params
-            _connectionParams["isClientReady"] = "1";  // sloppy: set to string "1" instead of True
+            _connectionParams["isClientReady"] = "1";
             string jsonStr = JsonConvert.SerializeObject(_connectionParams, Formatting.None, _jsonSettings);
             websocket.SendText(jsonStr);
             Debug.Log("Sent message: client ready!");

--- a/Assets/Scripts/NetworkClient.cs
+++ b/Assets/Scripts/NetworkClient.cs
@@ -229,13 +229,15 @@ public class NetworkClient : IUpdatable
 
             if (isConnected())
             {
-                // Log the count of received messages
-                float messageRate = (float)messagesReceivedCount / duration;
-
-                Debug.Log($"Message rate: {messageRate.ToString("F1")}, FPS: {fps.ToString("F1")}");
-
-                _player.SetKeyframeRate(messageRate);
-            } else
+                if (messagesReceivedCount > 0 && duration > 0)
+                {
+                    // Log the count of received messages
+                    float messageRate = (float)messagesReceivedCount / duration;
+                    Debug.Log($"Message rate: {messageRate.ToString("F1")}, FPS: {fps.ToString("F1")}");
+                    _player.SetKeyframeRate(messageRate);
+                }
+            }
+            else
             {
                 Debug.Log($"disconnected, FPS: {fps.ToString("F1")}");
             }

--- a/Assets/Scripts/ServerKeyframeIdHandler.cs
+++ b/Assets/Scripts/ServerKeyframeIdHandler.cs
@@ -7,5 +7,10 @@ public class ServerKeyframeIdHandler : IKeyframeMessageConsumer
         recentServerKeyframeId = message.serverKeyframeId;
     }
 
+    public void Reset()
+    {
+        recentServerKeyframeId = null;
+    }
+
     public void Update() {}
 }

--- a/Assets/Scripts/ServerKeyframeIdHandler.cs
+++ b/Assets/Scripts/ServerKeyframeIdHandler.cs
@@ -1,0 +1,11 @@
+public class ServerKeyframeIdHandler : IKeyframeMessageConsumer
+{
+    public int? recentServerKeyframeId { get; private set; } = null;
+
+    public void ProcessMessage(Message message)
+    {
+        recentServerKeyframeId = message.serverKeyframeId;
+    }
+
+    public void Update() {}
+}

--- a/Assets/Scripts/ServerKeyframeIdHandler.cs.meta
+++ b/Assets/Scripts/ServerKeyframeIdHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eb46274ad5dd654a38f2a019170803c3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Tests/EditMode/TestConnectionParameters.cs
+++ b/Assets/Scripts/Tests/EditMode/TestConnectionParameters.cs
@@ -203,7 +203,7 @@ namespace Habitat.Tests.EditMode
             Assert.AreEqual(portRange.Value.portStart, 2222);
             Assert.AreEqual(portRange.Value.portEnd, 3333);
 
-            // Decreasing port range. We expect output to be flipped.
+            // Decreasing port range. Output is expected to be in increasing order.
             url = "test?server_port_range=3333-2222";
             parameters = ConnectionParameters.GetConnectionParameters(url);
             portRange = ConnectionParameters.GetServerPortRange(parameters);

--- a/Assets/Scripts/Tests/EditMode/TestConnectionParameters.cs
+++ b/Assets/Scripts/Tests/EditMode/TestConnectionParameters.cs
@@ -142,36 +142,89 @@ namespace Habitat.Tests.EditMode
         }
 
         [Test]
-        public void TestGetServerPort()
+        public void TestTryParsePortString()
         {
-            string url;
-            int? port;
-            Dictionary<string, string> parameters;
+            int port;
+            bool result;
 
             // Valid cases.
             LogAssert.ignoreFailingMessages = false;
 
             // Canonical case.
-            url = "test?server_hostname=HOST&server_port=1111&test=true";
-            parameters = ConnectionParameters.GetConnectionParameters(url);
-            port = ConnectionParameters.GetServerPort(parameters);
+            result = ConnectionParameters.TryParsePortString("1111", out port);
+            Assert.AreEqual(result, true);
             Assert.AreEqual(port, 1111);
+
+            // Null string.
+            result = ConnectionParameters.TryParsePortString(null, out port);
+            Assert.AreEqual(result, false);
+
+            // Empty string.
+            result = ConnectionParameters.TryParsePortString("", out port);
+            Assert.AreEqual(result, false);
+
+            // Negative port.
+            result = ConnectionParameters.TryParsePortString("-55", out port);
+            Assert.AreEqual(result, false);
+
+            // Port > 65535.
+            result = ConnectionParameters.TryParsePortString("100000", out port);
+            Assert.AreEqual(result, false);
+        }
+
+        [Test]
+        public void TestGetServerPortRange()
+        {
+            string url;
+            (int portStart, int portEnd)? portRange;
+            Dictionary<string, string> parameters;
+
+            // Valid cases.
+            LogAssert.ignoreFailingMessages = false;
+
+            // Canonical server_port.
+            url = "test?server_hostname=HOST&server_port=2222&test=true";
+            parameters = ConnectionParameters.GetConnectionParameters(url);
+            portRange = ConnectionParameters.GetServerPortRange(parameters);
+            Assert.AreEqual(portRange.Value.portStart, 2222);
+            Assert.AreEqual(portRange.Value.portEnd, 2222);
+
+            // Canonical server_port_range.
+            url = "test?server_hostname=HOST&server_port_range=2222-3333&test=true";
+            parameters = ConnectionParameters.GetConnectionParameters(url);
+            portRange = ConnectionParameters.GetServerPortRange(parameters);
+            Assert.AreEqual(portRange.Value.portStart, 2222);
+            Assert.AreEqual(portRange.Value.portEnd, 3333);
+
+            // Both server_port and server_port_range. 'server_port_range' has priority.
+            url = "test?server_port_range=2222-3333&server_port=4444";
+            parameters = ConnectionParameters.GetConnectionParameters(url);
+            portRange = ConnectionParameters.GetServerPortRange(parameters);
+            Assert.AreEqual(portRange.Value.portStart, 2222);
+            Assert.AreEqual(portRange.Value.portEnd, 3333);
+
+            // Decreasing port range. We expect output to be flipped.
+            url = "test?server_port_range=3333-2222";
+            parameters = ConnectionParameters.GetConnectionParameters(url);
+            portRange = ConnectionParameters.GetServerPortRange(parameters);
+            Assert.AreEqual(portRange.Value.portStart, 2222);
+            Assert.AreEqual(portRange.Value.portEnd, 3333);
 
             // No port.
             url = "test?test=test";
             parameters = ConnectionParameters.GetConnectionParameters(url);
-            port = ConnectionParameters.GetServerPort(parameters);
-            Assert.AreEqual(port, null);
+            portRange = ConnectionParameters.GetServerPortRange(parameters);
+            Assert.AreEqual(portRange, null);
 
             // No parameter.
             url = "test";
             parameters = ConnectionParameters.GetConnectionParameters(url);
-            port = ConnectionParameters.GetServerPort(parameters);
-            Assert.AreEqual(port, null);
+            portRange = ConnectionParameters.GetServerPortRange(parameters);
+            Assert.AreEqual(portRange, null);
 
             // Null input
-            port = ConnectionParameters.GetServerPort(null);
-            Assert.AreEqual(port, null);
+            portRange = ConnectionParameters.GetServerPortRange(null);
+            Assert.AreEqual(portRange, null);
 
             // Invalid cases.
             LogAssert.ignoreFailingMessages = true;
@@ -179,20 +232,38 @@ namespace Habitat.Tests.EditMode
             // Invalid port.
             url = "test?server_port=test";
             parameters = ConnectionParameters.GetConnectionParameters(url);
-            port = ConnectionParameters.GetServerPort(parameters);
-            Assert.AreEqual(port, null);
+            portRange = ConnectionParameters.GetServerPortRange(parameters);
+            Assert.AreEqual(portRange, null);
+
+            // Invalid port range.
+            url = "test?server_port_range=test";
+            parameters = ConnectionParameters.GetConnectionParameters(url);
+            portRange = ConnectionParameters.GetServerPortRange(parameters);
+            Assert.AreEqual(portRange, null);
+
+            // '-' port range.
+            url = "test?server_port_range=-";
+            parameters = ConnectionParameters.GetConnectionParameters(url);
+            portRange = ConnectionParameters.GetServerPortRange(parameters);
+            Assert.AreEqual(portRange, null);
+            
+            // Invalid port range portion.
+            url = "test?server_port_range=test-test2";
+            parameters = ConnectionParameters.GetConnectionParameters(url);
+            portRange = ConnectionParameters.GetServerPortRange(parameters);
+            Assert.AreEqual(portRange, null);
 
             // Negative port.
             url = "test?server_port=-100";
             parameters = ConnectionParameters.GetConnectionParameters(url);
-            port = ConnectionParameters.GetServerPort(parameters);
-            Assert.AreEqual(port, null);
+            portRange = ConnectionParameters.GetServerPortRange(parameters);
+            Assert.AreEqual(portRange, null);
 
             // Port > 65535.
             url = "test?server_port=1000000";
             parameters = ConnectionParameters.GetConnectionParameters(url);
-            port = ConnectionParameters.GetServerPort(parameters);
-            Assert.AreEqual(port, null);
+            portRange = ConnectionParameters.GetServerPortRange(parameters);
+            Assert.AreEqual(portRange, null);
 
             LogAssert.ignoreFailingMessages = false;
         }


### PR DESCRIPTION
This adds the following features:
* Port range parsing from URL query string.
* Echo `serverKeyframeId` to server for latency measurements.
* Add on-screen disconnect status text.
* Fix for assert in `SetKeyframeRate`.

This was added from @eundersander's commits here, adapting them to `main`:
* [7bd39bbfc97195c8e7c5dda9af45d854ea642f74](https://github.com/eundersander/siro_hitl_unity_client/commit/7bd39bbfc97195c8e7c5dda9af45d854ea642f74)
* [122ec121803ec21b4e773708e0cf6482f1160d1e](https://github.com/eundersander/siro_hitl_unity_client/commit/122ec121803ec21b4e773708e0cf6482f1160d1e)
* [09d29c7f4ff8a7f5df62c024f01288e7f96d80fb](https://github.com/eundersander/siro_hitl_unity_client/commit/09d29c7f4ff8a7f5df62c024f01288e7f96d80fb)

Note that because `main` lacks proper text support, a placeholder ImGUI text render was added for `NetworkClient`.