### PR TITLE
Asynchronous skinned mesh loading.

### DIFF
--- a/Assets/Scripts/GfxReplaySkinnedMesh.cs
+++ b/Assets/Scripts/GfxReplaySkinnedMesh.cs
@@ -1,50 +1,91 @@
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Assertions;
 
 /// <summary>
 /// Allows to control a skinned/rigged mesh from gfx-replay "RigCreation" and "RigUpdate" keyframes.
-/// The component is expected to be added to the root object of a skinned mesh.
+/// Acts as a placeholder until 'Initialize' is called, and until the first 'RigCreation' is received.
 /// </summary>
-public class GfxReplaySkinnedMesh : MonoBehaviour
+public class GfxReplaySkinnedMesh
 {
-    /// <summary>
-    /// Gfx-replay rigId associated with this skinned mesh.
-    /// </summary>
-    public int rigId {get; set;} = Constants.ID_UNDEFINED;
-
     private Transform[] _bones;
 
     SkinnedMeshRenderer _skinnedMeshRenderer;
+    GfxReplayInstance _parent;
+    bool _initialized = false;
+    List<string> _boneNames;
+    RigUpdate _lastRigUpdate;
 
-    void Awake()
+    public GfxReplaySkinnedMesh(GfxReplayInstance parent)
     {
-        // Find the skinned mesh renderer.
-        // This component is automatically created by the asset pipeline upon importing a skinned mesh.
-        _skinnedMeshRenderer = GetComponentInChildren<SkinnedMeshRenderer>();
-        if (_skinnedMeshRenderer == null)
+        _parent = parent;
+    }
+
+    /// <summary>
+    /// Initialize the skinned mesh.
+    /// To be called after the skinned mesh has been loaded.
+    /// </summary>
+    public void Initialize(SkinnedMeshRenderer skinnedMeshRenderer)
+    {
+        if (skinnedMeshRenderer == null)
         {
-            Debug.LogError($"Object '{name}' has no SkinnedMeshRenderer. Skinning will not be applied.");
-            enabled = false;
             return;
         }
+        _skinnedMeshRenderer = skinnedMeshRenderer;
 
         // Hide the skinned mesh until it is configured (i.e. until RigCreation is received).
         _skinnedMeshRenderer.enabled = false;
 
-        // We don't update bounds every update. Instead, we never cull the skinned mesh.
+        // We don't update the bounding box every update manually.
         _skinnedMeshRenderer.updateWhenOffscreen = true;
+
+        // If we already received bone names from gfx-replay, start mapping.
+        if (_boneNames != null)
+        {
+            mapGfxReplayBonesToSkinnedMesh(_boneNames);
+        }
     }
 
-    public void configureRigInstance(List<string> boneNames)
+    public void ProcessRigCreation(RigCreation rigCreation)
     {
-        if (!enabled)
+        _boneNames = rigCreation.boneNames;
+        mapGfxReplayBonesToSkinnedMesh(_boneNames);
+    }
+
+    public void ProcessRigUpdate(RigUpdate rigUpdate) {
+        // If the skinned mesh is not yet initialized, remember the pose so that it can be applied after loading.
+        if (!_initialized)
+        {
+            _lastRigUpdate = rigUpdate;
+            return;
+        }
+
+        var pose = rigUpdate.pose;
+        Assert.IsNotNull(_bones);
+        Assert.AreEqual(pose.Count, _bones.Length);
+
+        for (int i = 0; i < pose.Count; ++i)
+        {
+            _bones[i].position = CoordinateSystem.ToUnityVector(pose[i].t);
+            // TODO: The bones are offset by 180 degrees around the Y-axis.
+            _bones[i].rotation = CoordinateSystem.ToUnityQuaternion(pose[i].r) * Quaternion.Euler(0, 180, 0);
+        }
+    }
+
+    /// <summary>
+    /// Map gfx-replay bone names to skinned mesh bone names so that 'RigUpdate' indices can be matched to a bone.
+    /// </summary>
+    void mapGfxReplayBonesToSkinnedMesh(List<string> boneNames)
+    {
+        Assert.IsNotNull(boneNames);
+
+        if (_initialized || _skinnedMeshRenderer == null)
         {
             return;
         }
         if (_skinnedMeshRenderer.bones.Length != boneNames.Count + 1) // 'boneNames' doesn't include the root.
         {
-            Debug.LogError($"Skinned object '{name}' does not have the same number of bones than the rig {rigId}.");
-            enabled = false;
+            Debug.LogError($"Skinned object '{_parent.name}' does not have the same number of bones than the rig {_parent.rigId}.");
             return;
         }
 
@@ -66,35 +107,18 @@ public class GfxReplaySkinnedMesh : MonoBehaviour
         }
         if (matchedBoneCount != boneNames.Count)
         {
-            Debug.LogError($"Skinned object '{name}' does not match the bones defined in rig {rigId}.");
-            enabled = false;
+            Debug.LogError($"Skinned object '{_parent.name}' does not match the bones defined in rig {_parent.rigId}.");
+            return;
         }
 
         _skinnedMeshRenderer.enabled = true;
-    }
+        _initialized = true;
 
-    public void setPose(List<RigUpdate.BoneTransform> pose) {
-        if (!enabled)
+        // If a pose was already received, apply it immediately.
+        if (_lastRigUpdate != null)
         {
-            return;
-        }
-        if (_bones == null)
-        {
-            Debug.LogError($"Skinned object '{name}' is not configured.");
-            enabled = false;
-            return;
-        }
-        if (pose == null || pose.Count != _bones.Length)
-        { 
-            Debug.LogError($"Invalid pose submitted to skinned object '{name}'.");
-            enabled = false;
-            return;
-        }
-
-        for (int i = 0; i < pose.Count; ++i)
-        {
-            _bones[i].position = CoordinateSystem.ToUnityVector(pose[i].t);
-            _bones[i].rotation = CoordinateSystem.ToUnityQuaternion(pose[i].r);
+            ProcessRigUpdate(_lastRigUpdate);
+            _lastRigUpdate = null;
         }
     }
 }

--- a/Assets/Scripts/PathUtils.cs
+++ b/Assets/Scripts/PathUtils.cs
@@ -1,0 +1,57 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+using UnityEngine.Assertions;
+
+/// <summary>
+/// Utilities for processing paths.
+/// </summary>
+public static class PathUtils
+{
+    /// <summary>
+    /// Remove '..' and '.' from a relative path.
+    /// </summary>
+    public static string SimplifyRelativePath(string path)
+    {
+        Assert.IsNotNull(path);
+        string[] parts = path.Split(new char[] { '/' }, System.StringSplitOptions.RemoveEmptyEntries);
+        var simplifiedParts = new List<string>();
+
+        foreach (var part in parts)
+        {
+            if (part == ".." && simplifiedParts.Count > 0)
+            {
+                simplifiedParts.RemoveAt(simplifiedParts.Count - 1);
+            }
+            else if (part != "." && part != "..")
+            {
+                simplifiedParts.Add(part);
+            }
+        }
+
+        return string.Join("/", simplifiedParts);
+    }
+
+    /// <summary>
+    /// Remove the file extension from a path.
+    /// </summary>
+    public static string RemoveExtension(string path)
+    {
+        Assert.IsNotNull(path);
+        if (path == "")
+        {
+            return "";
+        }
+        return Path.Join(Path.GetDirectoryName(path), Path.GetFileNameWithoutExtension(path));
+    }
+
+    /// <summary>
+    /// Converts a Habitat path into a Unity address asset.
+    /// </summary>
+    public static string HabitatPathToUnityAddress(string path)
+    {
+        Assert.IsNotNull(path);
+        return RemoveExtension(SimplifyRelativePath(path));
+    }
+}

--- a/Assets/Scripts/PathUtils.cs.meta
+++ b/Assets/Scripts/PathUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b5ddd3ec3d0791a45ada1424850bff00
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Tests/EditMode/TestPathUtils.cs
+++ b/Assets/Scripts/Tests/EditMode/TestPathUtils.cs
@@ -1,0 +1,78 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Habitat.Tests.EditMode
+{
+    public class TestPathUtils
+    {
+        [Test]
+        public void TestSimplifyRelativePath()
+        {
+            Assert.AreEqual(
+                "a/b/c.test",
+                PathUtils.SimplifyRelativePath("a/././b/c.test")
+            );
+            Assert.AreEqual(
+                "b/c.test",
+                PathUtils.SimplifyRelativePath("a/./../b/c.test")
+            );
+            Assert.AreEqual(
+                "test",
+                PathUtils.SimplifyRelativePath("test")
+            );
+            Assert.AreEqual(
+                "",
+                PathUtils.SimplifyRelativePath("")
+            );
+            Assert.AreEqual(
+                "",
+                PathUtils.SimplifyRelativePath("./././.")
+            );
+        }
+
+        [Test]
+        public void TestRemoveExtension()
+        {
+            Assert.AreEqual(
+                "test",
+                PathUtils.RemoveExtension("test.test")
+            );
+            Assert.AreEqual(
+                "a.b",
+                PathUtils.RemoveExtension("a.b.c")
+            );
+            Assert.AreEqual(
+                "/home/test/test",
+                PathUtils.RemoveExtension("/home/test/test.test")
+            );
+            Assert.AreEqual(
+                "",
+                PathUtils.RemoveExtension("")
+            );
+        }
+
+        [Test]
+        public void TestHabitatPathToUnityAddress()
+        {
+            Assert.AreEqual(
+                "data/test_dataset/a/b/c/d/e/asset",
+                PathUtils.HabitatPathToUnityAddress("data/test_dataset/a/b/c/d/e/asset.glb")
+            );
+            Assert.AreEqual(
+                "data/test_dataset/a/b/c/d/e/asset",
+                PathUtils.HabitatPathToUnityAddress("data/test_dataset/a/b/c/d/e/asset")
+            );
+            Assert.AreEqual(
+                "data/test_dataset/a/b/c/d/e/asset",
+                PathUtils.HabitatPathToUnityAddress("data/123/../test_dataset/a/b/./c/d/f/g/.././../e/asset.glb")
+            );
+            Assert.AreEqual(
+                "",
+                PathUtils.HabitatPathToUnityAddress("")
+            );
+        }
+    }
+}

--- a/Assets/Scripts/Tests/EditMode/TestPathUtils.cs.meta
+++ b/Assets/Scripts/Tests/EditMode/TestPathUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e2820f1df181077fb94e130a46bf1ef6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This changeset allows skinned meshes to be loaded asynchronously.

This is done by making the `gfx-replay` player manipulate placeholder objects until the final model is loaded.

The following changes are applied:
* Decoupling of `GfxReplaySkinnedMesh` and `GfxReplayPlayer` by delegating all initialization to `GfxReplayInstance`.
* Move path utilities to its own file (+ tests).
* Fix for skinned mesh orientation.
    * Still need to figure out where this 180 degree offset comes from.
