### PR TITLE
Add Update() function to CoroutineContainer.

### DIFF
--- a/Assets/Scripts/CoroutineContainer.cs
+++ b/Assets/Scripts/CoroutineContainer.cs
@@ -16,6 +16,12 @@ public class CoroutineContainer : MonoBehaviour
         return new GameObject(name).AddComponent<CoroutineContainer>();
     }
 
+    void Update()
+    {
+        // This magic is required for coroutines to continue executing after the `yield` keyword.
+        return;
+    }
+
     // The string 'methodName' argument requires the target method to be within a MonoBehavior object.
     // Use the newer StartCoroutine(IEnumerator) instead.
     new public void CancelInvoke()


### PR DESCRIPTION
`CoroutineContainer` is a class that allows to use [coroutines](https://docs.unity3d.com/Manual/Coroutines.html) in classes that are not [MonoBehaviour](https://docs.unity3d.com/ScriptReference/MonoBehaviour.html).

To mimic asynchronicity, the `yield` keyword is used to mark the end of a co-routine code block (the scheduler will execute the other portions of the function later).

In the current state, the scheduler doesn't pick up the deferred function calls. Only the first coroutine portion is executed (it's executed immediately after creating the coroutine).

This changeset adds an `Update()` method to `CoroutineContainer` to fix this.