### PR TITLE
Add Addressables and implement remote content hosting.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,13 +10,6 @@
 /[Ll]ogs/
 /[Uu]ser[Ss]ettings/
 
-# hack to identify other build folders
-/*DoNotShip/
-
-# this is SIRo data that will be installed separately from source control
-/Assets/Resources/data
-/Assets/Resources/data.meta
-
 # Mac OS file
 .DS_Store
 
@@ -91,3 +84,22 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
+
+### Habitat-Specific
+
+# Imported Habitat data folder.
+/Assets/HabitatData/
+/Assets/HabitatData.meta
+
+# Legacy Habitat data folder.
+/Assets/Resources/data
+/Assets/Resources/data.meta
+
+# Addressable Assets
+# It is generally recommended to version these assets.
+# However, in our case, we procedurally generate them based on imported Habitat data.
+/Assets/AddressableAssetsData/
+/Assets/AddressableAssetsData.meta
+
+# Remote assets.
+/ServerData

--- a/Assets/Scripts/ConnectionParameters.cs
+++ b/Assets/Scripts/ConnectionParameters.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Web;
 using UnityEngine;
 
@@ -128,6 +129,91 @@ public static class ConnectionParameters
             else
             {
                 Debug.LogError($"Invalid server_port: '{serverPortString}'. Expected format: 'server_port=2222'.");
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Get a valid asset hostname from query parameters.
+    /// The 'asset_hostname' parameter defines where to fetch remote assets.
+    /// </summary>
+    /// <param name="queryParams">See GetConnectionParameters().</param>
+    /// <returns>Hostname string. Returns null if the input does not contain a valid hostname.</returns>
+    public static string? GetAssetHostname(Dictionary<string, string> queryParams)
+    {
+        if (queryParams == null) return null;
+
+        if (queryParams.TryGetValue("asset_hostname", out string assetHostnameString))
+        {
+            if (Uri.CheckHostName(assetHostnameString) != UriHostNameType.Unknown)
+            {
+                return assetHostnameString;
+            }
+            else
+            {
+                Debug.LogError($"Invalid asset_hostname: '{assetHostnameString}'");
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Get a valid asset port from query parameters.
+    /// The 'asset_port' parameter defines where to fetch remote assets.
+    /// </summary>
+    /// <param name="queryParams">See GetConnectionParameters().</param>
+    /// <returns>Port. Returns null if the input does not contain a valid port.</returns>
+    public static int? GetAssetPort(Dictionary<string, string> queryParams)
+    {
+        if (queryParams == null) return null;
+
+        if (queryParams.TryGetValue("asset_port", out string assetPortString))
+        {
+            if (TryParsePortString(assetPortString, out int port))
+            {
+                return port;
+            }
+            else
+            {
+                Debug.LogError($"Invalid asset_port: '{assetPortString}'. Expected format: 'asset_port=2222'.");
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Get a valid asset path from query parameters.
+    /// The 'asset_path' parameter defines where to fetch remote assets.
+    /// </summary>
+    /// <param name="queryParams">See GetConnectionParameters().</param>
+    /// <returns>Port. Returns null if the input does not contain a valid path.</returns>
+    public static string? GetAssetPath(Dictionary<string, string> queryParams)
+    {
+        if (queryParams == null) return null;
+
+        if (queryParams.TryGetValue("asset_path", out string assetPathString))
+        {
+            char[] validSpecialChars = {'-', '_', '.', '!', '/', '(', ')'};
+            bool valid = true;
+            foreach (char c in assetPathString)
+            {
+                if (!char.IsLetterOrDigit(c) && !validSpecialChars.Contains(c))
+                {
+                    valid = false;
+                    break;
+                }
+            }
+            if (valid)
+            {
+                return assetPathString;
+            }
+            else
+            {
+                Debug.LogError($"Invalid asset_path: '{assetPathString}'");
             }
         }
 

--- a/Assets/Scripts/Editor.meta
+++ b/Assets/Scripts/Editor.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 12fb4463fe7204ab5a11d67908b708a9
+guid: 221b8f16ddb50dacda822f43f2a73120
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/Scripts/Editor/AddressablesEditor.cs
+++ b/Assets/Scripts/Editor/AddressablesEditor.cs
@@ -37,11 +37,7 @@ public static class AddressablesEditor
     {
         return File.Exists(EDITOR_HABITAT_METADATA_PATH);
     }
-    public static string PackageToUnityPath(string path)
-    {
-        return Path.Combine(INPUT_ASSET_FOLDER, path);
-    }
-    public static string PackageToHabitatPath(string path)
+    public static string AddressToUnityPath(string path)
     {
         return Path.Combine(INPUT_ASSET_FOLDER, path);
     }
@@ -337,10 +333,10 @@ public static class AddressablesEditor
             }
         }
 
-        // Read metadata json file
+        // Read metadata json file.
         var metadataFile = ReadMetadataFile();
 
-        // Move to function
+        // Generate addressable groups.
         var remoteGroup = CreateAddressableGroup("remote");
         {
             BundledAssetGroupSchema bags = CreateOrGetAddressableGroupSchema<BundledAssetGroupSchema>(remoteGroup);
@@ -363,7 +359,6 @@ public static class AddressablesEditor
             remoteGroup.GetSchema<BundledAssetGroupSchema>().LoadPath.SetVariableById(settings, idInfo.Id);
             settings.SetDirty(AddressableAssetSettings.ModificationEvent.GroupSchemaModified, remoteGroup, true);
         }
-        // Move to function
         var localGroup = CreateAddressableGroup(metadataFile.local_group_name);
         {
             BundledAssetGroupSchema bags = CreateOrGetAddressableGroupSchema<BundledAssetGroupSchema>(localGroup);
@@ -385,9 +380,7 @@ public static class AddressablesEditor
             settings.SetDirty(AddressableAssetSettings.ModificationEvent.GroupSchemaModified, localGroup, true);
         }
 
-        // Create short labels so that generated file names remain sane.
         uint labelCounter = 0;
-
         foreach (var group in metadataFile.groups)
         {
             // Check if this is the local package.
@@ -401,14 +394,14 @@ public static class AddressablesEditor
                 settings.AddLabel(label);
             }
 
-            foreach (var assetPath in group.Value)
+            foreach (var address in group.Value)
             {
                 // Check whether this asset needs to be packaged with the local group.
                 // TODO: If the asset is in all remote packages, mark it as local.
                 bool isLocalAsset = isLocalGroup;
 
                 // Identify the asset in Unity.
-                var unityAssetPath = PackageToUnityPath(assetPath);
+                var unityAssetPath = AddressToUnityPath(address);
                 string guid = GetAssetGUID(unityAssetPath);
 
                 // Assign the group.
@@ -417,12 +410,12 @@ public static class AddressablesEditor
                 var entry = settings.FindAssetEntry(guid);
                 if (entry == null)
                 {
-                    Debug.LogError($"Asset {assetPath} was not imported correctly into Unity. It will be excluded from the catalog.");
+                    Debug.LogError($"Asset {address} was not imported correctly into Unity. It will be excluded from the catalog.");
                     continue;
                 }
 
                 // Assign the address.
-                entry.address = PackageToHabitatPath(assetPath);
+                entry.address = address;
 
                 // Assign the label.
                 // Unity will package all assets with the same combination of labels together.

--- a/Assets/Scripts/Editor/AddressablesEditor.cs
+++ b/Assets/Scripts/Editor/AddressablesEditor.cs
@@ -308,7 +308,7 @@ public static class AddressablesEditor
             //     Using magic, the addressable system will find the static variables in the HabitatAssetServer static class.
             //     See https://docs.unity3d.com/Packages/com.unity.addressables@1.18/manual/AddressableAssetsProfiles.html.
             //     Therefore, the static variables 'HabitatAssetServer.Address' and 'HabitatAssetServer.Port' must be set before calling any Addressables API.
-            settings.profileSettings.SetValue(id, "Remote.LoadPath", "http://{HabitatAssetServer.Address}:{HabitatAssetServer.Port}/[BuildTarget]");
+            settings.profileSettings.SetValue(id, "Remote.LoadPath", "{HabitatAssetServer.Protocol}://{HabitatAssetServer.Address}:{HabitatAssetServer.Port}/{HabitatAssetServer.Path}/[BuildTarget]");
             settings.profileSettings.SetDirty(AddressableAssetSettings.ModificationEvent.ProfileAdded, id, true);
             // Set active profile.
             settings.activeProfileId = id;

--- a/Assets/Scripts/Editor/AddressablesEditor.cs
+++ b/Assets/Scripts/Editor/AddressablesEditor.cs
@@ -394,14 +394,14 @@ public static class AddressablesEditor
                 settings.AddLabel(label);
             }
 
-            foreach (var address in group.Value)
+            foreach (var fileName in group.Value)
             {
                 // Check whether this asset needs to be packaged with the local group.
                 // TODO: If the asset is in all remote packages, mark it as local.
                 bool isLocalAsset = isLocalGroup;
 
                 // Identify the asset in Unity.
-                var unityAssetPath = AddressToUnityPath(address);
+                var unityAssetPath = AddressToUnityPath(fileName);
                 string guid = GetAssetGUID(unityAssetPath);
 
                 // Assign the group.
@@ -410,12 +410,14 @@ public static class AddressablesEditor
                 var entry = settings.FindAssetEntry(guid);
                 if (entry == null)
                 {
-                    Debug.LogError($"Asset {address} was not imported correctly into Unity. It will be excluded from the catalog.");
+                    Debug.LogError($"Asset {fileName} was not imported correctly into Unity. It will be excluded from the catalog.");
                     continue;
                 }
 
                 // Assign the address.
-                entry.address = address;
+                // Habitat excludes the extension, so we remove the extension here.
+                int extensionLength = new FileInfo(fileName).Extension.Length;
+                entry.address = fileName[..^extensionLength];
 
                 // Assign the label.
                 // Unity will package all assets with the same combination of labels together.
@@ -438,6 +440,9 @@ public static class AddressablesEditor
         {
             Directory.Delete(OUTPUT_ASSET_FOLDER, true);
         }
+
+        // Clean builder cache.
+        AddressableAssetSettings.CleanPlayerContent(AddressableAssetSettingsDefaultObject.Settings.ActivePlayerDataBuilder);
 
         // Build addressables using the current platform.
         AddressableAssetSettings.BuildPlayerContent();

--- a/Assets/Scripts/Editor/AddressablesEditor.cs
+++ b/Assets/Scripts/Editor/AddressablesEditor.cs
@@ -1,0 +1,482 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+using System;
+using Newtonsoft.Json;
+using System.IO;
+using UnityEngine.AddressableAssets;
+using UnityEditor.AddressableAssets.Settings;
+using UnityEditor.AddressableAssets;
+using UnityEditor.AddressableAssets.Settings.GroupSchemas;
+using System.Linq;
+using System.Data;
+using Newtonsoft.Json.Linq;
+
+namespace Habitat.Editor
+{
+public static class AddressablesEditor
+{
+    [Serializable]
+    // Metadata file content.
+    public class MetadataFile
+    {
+        public int version;
+        public string local_group_name;
+        public Dictionary<string, List<string>> groups;
+    }
+
+    public const string METADATA_FILE_NAME = "metadata.json";
+    public const int METADATA_FILE_VERSION = 1;
+    public const string INPUT_ASSET_FOLDER = "Assets/HabitatData";
+    public const string EDITOR_HABITAT_METADATA_PATH = INPUT_ASSET_FOLDER + "/" + METADATA_FILE_NAME;
+    public const string OUTPUT_ASSET_FOLDER = "ServerData";
+    const string PROFILE_NAME = "habitat";
+
+    public static bool MetadataExist()
+    {
+        return File.Exists(EDITOR_HABITAT_METADATA_PATH);
+    }
+    public static string PackageToUnityPath(string path)
+    {
+        return Path.Combine(INPUT_ASSET_FOLDER, path);
+    }
+    public static string PackageToHabitatPath(string path)
+    {
+        return Path.Combine(INPUT_ASSET_FOLDER, path);
+    }
+
+    /// <summary>
+    /// Create a short package name.
+    /// Label names are combined together. To avoid collisions, the first character is alpha and subsequent characters are digits.
+    /// Examples: "a", "F0", "d94"
+    /// </summary>
+    /// <param name="counter">Sequential counter from which a label name is created.</param>
+    /// <returns></returns>
+    public static string CreateShortLabelName(uint counter)
+    {
+        const uint LETTER_COUNT = 52;
+        const uint LOWERCASE_COUNT = 26;
+        const uint LOWERCASE_INDEX = 'a';
+        const uint UPPERCASE_INDEX = 'A';
+        uint char_index = counter % LETTER_COUNT;
+        uint alpha_index = counter % LOWERCASE_COUNT;
+        uint char_range = char_index < LOWERCASE_COUNT ? LOWERCASE_INDEX : UPPERCASE_INDEX;
+        uint digits = counter / LETTER_COUNT;
+        char prefix = (char)(char_range + alpha_index);
+        string suffix = digits == 0 ? "" : (digits - 1u).ToString();
+        return prefix + suffix;
+    }
+
+    public static MetadataFile ReadMetadataFile()
+    {
+        if (!MetadataExist())
+        {
+            Debug.LogError($"Cannot find {EDITOR_HABITAT_METADATA_PATH}.");
+            return null;
+        }
+
+        string textContent = File.ReadAllText(EDITOR_HABITAT_METADATA_PATH);
+
+        // Parse version without the type system to warn whether backward compatibility has been broken.
+        dynamic dictContent = JObject.Parse(textContent);
+        int? version = dictContent.version;
+        if (version == null || METADATA_FILE_VERSION != version.Value)
+        {
+            Debug.LogWarning($"This Unity project supports {METADATA_FILE_NAME} version {METADATA_FILE_VERSION}. The selected metadata file (version {version}) may not work as intended.");
+        }
+
+        return JsonConvert.DeserializeObject<MetadataFile>(textContent, new JsonSerializerSettings());
+    }
+
+    public static AssetReference AddAssetToAddressables(string guid)
+    {
+        AddressableAssetSettings settings = AddressableAssetSettingsDefaultObject.Settings;
+        return settings.CreateAssetReference(guid);
+    }
+
+    public static string GetAssetGUID(string unityAssetPath)
+    {
+        return AssetDatabase.AssetPathToGUID(unityAssetPath);
+    }
+
+    /// <summary>
+    /// Returns true if the asset is in all groups.
+    /// In this case, the asset will be provided along with the build.
+    /// </summary>
+    static bool ShouldAssetBePackagedInLocalGroup(string assetAddress, Dictionary<string, int> occurrences, int packageCountWithoutLocal)
+    {
+        if (occurrences.TryGetValue(assetAddress, out int occurrence))
+        {
+            return occurrence == packageCountWithoutLocal;
+        }
+        else
+        {
+            Debug.LogError($"Unknown asset: {assetAddress}");
+            return false;
+        }
+    }
+
+    [MenuItem ("Habitat/Open Remote Asset Directory")]
+    static void OpenRemoteAssetDirectory()
+    {
+        string outputDataDir = Path.Combine(Directory.GetCurrentDirectory(), OUTPUT_ASSET_FOLDER);
+        if (Directory.Exists(outputDataDir))
+        {
+            Application.OpenURL($"file://{outputDataDir}");
+        }
+        else
+        {
+            Debug.LogError("The server asset directory has not been created. Use 'Habitat/Build Catalog' to build it.");
+        }
+    }
+
+    static void CopyDirectory(string sourceDir, string destinationDir, bool recursive)
+    {
+        var sourceInfo = new DirectoryInfo(sourceDir);
+        if (!sourceInfo.Exists)
+        {
+            throw new DirectoryNotFoundException($"Source directory not found: {sourceInfo.FullName}");
+        }
+
+        DirectoryInfo[] sourceDirs = sourceInfo.GetDirectories();
+        Directory.CreateDirectory(destinationDir);
+
+        foreach (FileInfo file in sourceInfo.GetFiles())
+        {
+            string targetFilePath = Path.Combine(destinationDir, file.Name);
+            file.CopyTo(targetFilePath, overwrite: true);
+        }
+
+        if (recursive)
+        {
+            foreach (DirectoryInfo subDir in sourceDirs)
+            {
+                string newDestinationDir = Path.Combine(destinationDir, subDir.Name);
+                CopyDirectory(subDir.FullName, newDestinationDir, true);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Search for the Habitat data folder. It is defined as the directory containing the metadata json file.
+    /// This function aims to improve developer experience by tolerating selection of a parent directory.
+    /// </summary>
+    /// <param name="inputDir">Candidate directory.</param>
+    /// <returns>Directory containing Habitat data. Returns null if invalid.</returns>
+    static string FindHabitatDataDirectory(string inputDir, int maxDepth = 2)
+    {
+        if (maxDepth <= 0)
+        {
+            return null;
+        }
+
+        // Check if directory contains metadata.
+        var inputInfo = new DirectoryInfo(inputDir);
+        {
+            var files = inputInfo.GetFiles();
+            foreach (var fileInfo in files)
+            {
+                if (fileInfo.Name == METADATA_FILE_NAME)
+                {
+                    return inputDir;
+                }
+            }
+        }
+        // Search for a valid subdirectory.
+        maxDepth--;
+        var subDirs = inputInfo.GetDirectories();
+        foreach (var subdirInfo in subDirs)
+        {
+            string subdirResult = FindHabitatDataDirectory(subdirInfo.FullName, maxDepth - 1);
+            if (subdirResult != null)
+            {
+                return subdirResult;
+            }
+        }
+        // If the directory tree does not contain metadata, return null.
+        return null;
+    }
+
+    /// <summary>
+    /// Import Habitat datasets (data folder) into the project.
+    /// The incoming data folder is expected to be beside a METADATA_FILE_NAME file.
+    /// After this step is done:
+    /// - The assets can be used in the Editor for testing.
+    /// - The addressables catalog can be built. See BuildCatalog().
+    /// </summary>
+    [MenuItem ("Habitat/Import Habitat Data")]
+    static void ImportHabitatDataDirectory()
+    {
+        string unityInputDataDir = Path.Combine(Directory.GetCurrentDirectory(), INPUT_ASSET_FOLDER);
+        if (Directory.Exists(unityInputDataDir))
+        {
+            if (!EditorUtility.DisplayDialog(
+                title: "Import Habitat Data",
+                message: $"This will delete all current Habitat data ({INPUT_ASSET_FOLDER}). Continue?",
+                ok: "OK",
+                cancel: "Cancel"
+            ))
+            return;
+        }
+        
+        string metadataPath = EditorUtility.OpenFilePanel(
+            title: $"Import {METADATA_FILE_NAME}.",
+            directory: "",
+            extension: "json"
+        );
+        if (metadataPath == null || !File.Exists(metadataPath))
+        {
+            return;
+        }
+
+        var subdirectories = new FileInfo(metadataPath).Directory.GetDirectories();
+        if (subdirectories.Length == 0)
+        {
+            Debug.LogWarning($"Specified '{METADATA_FILE_NAME}' should be packaged with a 'data' folder.");
+            return;
+        }
+
+        if (Directory.Exists(unityInputDataDir))
+        {
+            Debug.Log($"Deleting {INPUT_ASSET_FOLDER} directory...");
+            Directory.Delete(unityInputDataDir, true);
+            string metaFilePath = unityInputDataDir + ".meta";
+            if (File.Exists(metaFilePath))
+            {
+                File.Delete(metaFilePath);
+            }
+            AssetDatabase.Refresh();
+        }
+        
+        Debug.Log($"Creating {INPUT_ASSET_FOLDER} directory...");
+        Directory.CreateDirectory(unityInputDataDir);
+
+        Debug.Log($"Importing {METADATA_FILE_NAME}...");
+        string inputMetadataFile = Path.Combine(unityInputDataDir, METADATA_FILE_NAME);
+        File.Copy(metadataPath, inputMetadataFile, overwrite: true);
+
+        Debug.Log("Importing Habitat Data Folder...");
+        CopyDirectory(new FileInfo(metadataPath).Directory.FullName, unityInputDataDir, recursive: true);
+
+        AssetDatabase.Refresh();
+    }
+
+    /// <summary>
+    /// This function builds the addressables catalog.
+    /// </summary>
+    [MenuItem ("Habitat/Build Catalog")]
+    static void BuildCatalog ()
+    {
+        if (!MetadataExist())
+        {
+            Debug.LogError("No data has been imported to Unity. Use 'Habitat/Import Habitat Data' before creating a catalog.");
+            return;
+        }
+
+        // HACK: Unity Addressables relies on serialized objects that are manually authored (AddressableAssetsData).
+        //       We are procedurally generating them, therefore including them in .gitignore.
+        //       GetSettings(true) initializes the Addressables assets for the project, which is normally done via Editor GUI.
+        if (!AddressableAssetSettingsDefaultObject.SettingsExists)
+        {
+            Debug.Log("Creating 'AddressableAssetsData'.");
+        }
+        var settings = AddressableAssetSettingsDefaultObject.GetSettings(create: true);
+        settings.BuildRemoteCatalog = true;
+        settings.BuildAddressablesWithPlayerBuild = AddressableAssetSettings.PlayerBuildOption.DoNotBuildWithPlayer;
+
+        // (Re)create custom profile
+        if (settings.profileSettings.GetAllProfileNames().Contains(PROFILE_NAME))
+        {
+            var id = settings.profileSettings.GetProfileId(PROFILE_NAME);
+            settings.profileSettings.RemoveProfile(id);
+            settings.profileSettings.SetDirty(AddressableAssetSettings.ModificationEvent.ProfileRemoved, id, true);
+        }
+        {
+            var id = settings.profileSettings.AddProfile(PROFILE_NAME, settings.activeProfileId);
+            settings.profileSettings.SetValue(id, "Local.BuildPath", "[UnityEngine.AddressableAssets.Addressables.BuildPath]/[BuildTarget]");
+            settings.profileSettings.SetValue(id, "Local.LoadPath", "{UnityEngine.AddressableAssets.Addressables.RuntimePath}/[BuildTarget]");
+            // Set remote build path.
+            // This path is where the files resulting from building addressables bundles will be located.
+            // These files must be put on the server for provisioning.
+            settings.profileSettings.SetValue(id, "Remote.BuildPath", $"{OUTPUT_ASSET_FOLDER}/[BuildTarget]");
+            // Set remote load path.
+            // This path is where the application will find the assets at runtime.
+            // The expressions in [brackets] are evaluated at build-time.
+            //     Because assets are platform-specific, one set of assets needs to be built for each platform (WebGL, Android, ...).
+            // The expressions in {braces} are evaluated at runtime, upon initializing the Addressables system.
+            //     Using magic, the addressable system will find the static variables in the HabitatAssetServer static class.
+            //     See https://docs.unity3d.com/Packages/com.unity.addressables@1.18/manual/AddressableAssetsProfiles.html.
+            //     Therefore, the static variables 'HabitatAssetServer.Address' and 'HabitatAssetServer.Port' must be set before calling any Addressables API.
+            settings.profileSettings.SetValue(id, "Remote.LoadPath", "http://{HabitatAssetServer.Address}:{HabitatAssetServer.Port}/[BuildTarget]");
+            settings.profileSettings.SetDirty(AddressableAssetSettings.ModificationEvent.ProfileAdded, id, true);
+            // Set active profile.
+            settings.activeProfileId = id;
+            settings.SetDirty(AddressableAssetSettings.ModificationEvent.ActiveProfileSet, id, true);
+            // HACK: Refresh main settings to reflect new values. Without this code, the behaviour is surprisingly flaky.
+            settings.RemoteCatalogLoadPath.SetVariableByName(settings, AddressableAssetSettings.kRemoteLoadPath);
+            settings.RemoteCatalogBuildPath.SetVariableByName(settings, AddressableAssetSettings.kRemoteBuildPath);
+        }
+        
+        // Re-create groups
+        AddressableAssetGroup[] groupsToRemove = settings.groups.Where(g => g != settings.DefaultGroup).ToArray();
+        foreach (var g in groupsToRemove)
+        {
+            settings.RemoveGroup(g);
+            settings.SetDirty(AddressableAssetSettings.ModificationEvent.GroupRemoved, g, true);
+        }
+
+        // Re-create labels
+        var labels = settings.GetLabels();
+        for (int i = 0; i < labels.Count; ++i)
+        {
+            string label = labels[i];
+            if (label != "default")
+            {
+                settings.RemoveLabel(label);
+            }
+        }
+
+        // Read metadata json file
+        var metadataFile = ReadMetadataFile();
+
+        // Move to function
+        var remoteGroup = CreateAddressableGroup("remote");
+        {
+            BundledAssetGroupSchema bags = CreateOrGetAddressableGroupSchema<BundledAssetGroupSchema>(remoteGroup);
+            bags.BundleMode = BundledAssetGroupSchema.BundlePackingMode.PackTogetherByLabel; // Create a bundle per unique set of labels.
+            bags.Compression = BundledAssetGroupSchema.BundleCompressionMode.LZ4;
+            bags.IncludeAddressInCatalog = true; // Enable loading assets by address.
+            bags.IncludeInBuild = true; // Enable building this group during AddressableAssetSettings.BuildPlayerContent().
+            bags.IncludeGUIDInCatalog = false; // Disable loading by AssetReference.
+            bags.IncludeLabelsInCatalog = true; // Disable labels - we only use them to create bundles.
+            bags.UseAssetBundleCache = true; // Enables local cache.
+            bags.UseAssetBundleCrc = true; // Enable loading assets from cache.
+            bags.AssetBundledCacheClearBehavior = BundledAssetGroupSchema.CacheClearBehavior.ClearWhenSpaceIsNeededInCache;
+            // This makes the system export the bundles and catalog at 'ServerData/[Platform]':
+            var idInfo = settings.profileSettings.GetProfileDataByName("Remote.BuildPath");
+            remoteGroup.GetSchema<BundledAssetGroupSchema>().BuildPath.SetVariableById(settings, idInfo.Id);
+            // This convoluted API enables the application to specify an IP and port to fetch the data.
+            // Unintuitively, the address where assets are located must be specified at build-time.
+            // String interpolation is used in runtime to change the address.
+            idInfo = settings.profileSettings.GetProfileDataByName("Remote.LoadPath");
+            remoteGroup.GetSchema<BundledAssetGroupSchema>().LoadPath.SetVariableById(settings, idInfo.Id);
+            settings.SetDirty(AddressableAssetSettings.ModificationEvent.GroupSchemaModified, remoteGroup, true);
+        }
+        // Move to function
+        var localGroup = CreateAddressableGroup(metadataFile.local_group_name);
+        {
+            BundledAssetGroupSchema bags = CreateOrGetAddressableGroupSchema<BundledAssetGroupSchema>(localGroup);
+            bags.BundleMode = BundledAssetGroupSchema.BundlePackingMode.PackTogether; // Create a single bundle.
+            bags.Compression = BundledAssetGroupSchema.BundleCompressionMode.LZ4;
+            bags.IncludeAddressInCatalog = true; // Enable loading assets by address.
+            bags.IncludeInBuild = true; // Enable building this group during AddressableAssetSettings.BuildPlayerContent().
+            bags.IncludeGUIDInCatalog = false; // Disable loading by AssetReference.
+            bags.IncludeLabelsInCatalog = false; // Disable labels.
+            bags.UseAssetBundleCache = true; // Enables local cache.
+            bags.UseAssetBundleCrc = true; // Enable loading assets from cache.
+            bags.AssetBundledCacheClearBehavior = BundledAssetGroupSchema.CacheClearBehavior.ClearWhenWhenNewVersionLoaded;
+            // This makes the system export bundles in a folder that Unity will package along with the build.
+            var idInfo = settings.profileSettings.GetProfileDataByName("Local.BuildPath");
+            localGroup.GetSchema<BundledAssetGroupSchema>().BuildPath.SetVariableById(settings, idInfo.Id);
+            // This tells Unity to load these assets locally.
+            idInfo = settings.profileSettings.GetProfileDataByName("Local.LoadPath");
+            localGroup.GetSchema<BundledAssetGroupSchema>().LoadPath.SetVariableById(settings, idInfo.Id);
+            settings.SetDirty(AddressableAssetSettings.ModificationEvent.GroupSchemaModified, localGroup, true);
+        }
+
+        // Create short labels so that generated file names remain sane.
+        uint labelCounter = 0;
+
+        foreach (var group in metadataFile.groups)
+        {
+            // Check if this is the local package.
+            bool isLocalGroup = group.Key == metadataFile.local_group_name;
+
+            // If this is not a local group, create a new label for items in this group.
+            // Labels can get pretty long when combined. Therefore, it is shortened.
+            string label = isLocalGroup ? null : CreateShortLabelName(labelCounter++);
+            if (label != null)
+            {
+                settings.AddLabel(label);
+            }
+
+            foreach (var assetPath in group.Value)
+            {
+                // Check whether this asset needs to be packaged with the local group.
+                // TODO: If the asset is in all remote packages, mark it as local.
+                bool isLocalAsset = isLocalGroup;
+
+                // Identify the asset in Unity.
+                var unityAssetPath = PackageToUnityPath(assetPath);
+                string guid = GetAssetGUID(unityAssetPath);
+
+                // Assign the group.
+                var addressableGroup = isLocalAsset ? localGroup : remoteGroup;
+                settings.CreateOrMoveEntry(guid, addressableGroup);
+                var entry = settings.FindAssetEntry(guid);
+                if (entry == null)
+                {
+                    Debug.LogError($"Asset {assetPath} was not imported correctly into Unity. It will be excluded from the catalog.");
+                    continue;
+                }
+
+                // Assign the address.
+                entry.address = PackageToHabitatPath(assetPath);
+
+                // Assign the label.
+                // Unity will package all assets with the same combination of labels together.
+                // If the package is local, we simply don't use the label and package it with the other local assets.
+                if (!isLocalAsset)
+                {
+                    entry.labels.Add(label);
+                }
+
+                // Update the serializable data so that changes are reflected in the Editor.
+                settings.SetDirty(AddressableAssetSettings.ModificationEvent.EntryMoved, entry, true);
+            }
+        }
+
+        // Save changes done to serializable settings and assets.
+        AssetDatabase.SaveAssets();
+
+        // Delete previous build output.
+        if (Directory.Exists(OUTPUT_ASSET_FOLDER))
+        {
+            Directory.Delete(OUTPUT_ASSET_FOLDER, true);
+        }
+
+        // Build addressables using the current platform.
+        AddressableAssetSettings.BuildPlayerContent();
+    }
+
+    public static AddressableAssetGroup CreateAddressableGroup(string groupName)
+    {
+        if (string.IsNullOrEmpty(groupName))
+        {   
+            Debug.LogError($"Invalid group name: {groupName}.");
+            return null;
+        }
+        
+        var addressableSettings = AddressableAssetSettingsDefaultObject.Settings;
+        var schemasToCopy = addressableSettings.DefaultGroup.Schemas;
+
+        AddressableAssetGroup group = addressableSettings.CreateGroup(
+            groupName:groupName,
+            setAsDefaultGroup:false,
+            readOnly: false,
+            postEvent: false,
+            schemasToCopy: schemasToCopy
+        );
+        
+        addressableSettings.SetDirty(AddressableAssetSettings.ModificationEvent.GroupAdded, group, true);
+
+        return group;
+    }
+
+    public static T CreateOrGetAddressableGroupSchema<T>(AddressableAssetGroup group) where T : AddressableAssetGroupSchema
+    {
+        return group.GetSchema<T>() ?? group.AddSchema<T>();
+    }
+}
+}

--- a/Assets/Scripts/Editor/AddressablesEditor.cs.meta
+++ b/Assets/Scripts/Editor/AddressablesEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6cd2a8fe18ec4861aa4143aa91c10b99
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Editor/Habitat.Editor.asmdef
+++ b/Assets/Scripts/Editor/Habitat.Editor.asmdef
@@ -1,0 +1,19 @@
+{
+    "name": "Habitat.Editor",
+    "rootNamespace": "",
+    "references": [
+        "Unity.Addressables.Editor",
+        "Unity.Addressables"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Scripts/Editor/Habitat.Editor.asmdef.meta
+++ b/Assets/Scripts/Editor/Habitat.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: aa5975c65f2d468ca8b1f0a87ff68a99
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Habitat.asmdef
+++ b/Assets/Scripts/Habitat.asmdef
@@ -10,7 +10,8 @@
         "Unity.XR.Interaction.Toolkit.Samples.StarterAssets",
         "Unity.XR.Interaction.Toolkit",
         "Unity.XR.Management",
-        "Unity.Addressables"
+        "Unity.Addressables",
+        "Unity.ResourceManager"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Assets/Scripts/Habitat.asmdef
+++ b/Assets/Scripts/Habitat.asmdef
@@ -9,7 +9,8 @@
         "Unity.XR.Interaction.Toolkit.Samples.DeviceSimulator",
         "Unity.XR.Interaction.Toolkit.Samples.StarterAssets",
         "Unity.XR.Interaction.Toolkit",
-        "Unity.XR.Management"
+        "Unity.XR.Management",
+        "Unity.Addressables"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Assets/Scripts/HabitatAssetServer.cs
+++ b/Assets/Scripts/HabitatAssetServer.cs
@@ -4,6 +4,7 @@
 /// The addressables system can reference static variables at initialization.
 /// This is done via profile variables. See https://docs.unity3d.com/Packages/com.unity.addressables@1.18/manual/AddressableAssetsProfiles.html. 
 /// Therefore, the static variables 'HabitatAssetServer.Address' and 'HabitatAssetServer.Port' must be set before calling any addressables API.
+/// In runtime, this is resolved to: "{Protocol}://{Address}:{Port}/{Path}/"
 /// See 'AddressablesEditor' for implementation.
 /// </summary>
 public static class HabitatAssetServer
@@ -19,4 +20,16 @@ public static class HabitatAssetServer
     /// Must be set before using any addressable API.
     /// </summary>
     public static string Port = "9999";
+
+    /// <summary>
+    /// Path to the remote 'ServerData'. This would typically be the location within a S3 bucket.
+    /// Must be set before using any addressable API.
+    /// </summary>
+    public static string Path = "";
+
+    /// <summary>
+    /// Protocol used to fetch addressable assets.
+    /// Must be set before using any addressable API.
+    /// </summary>
+    public static string Protocol = "http";
 }

--- a/Assets/Scripts/HabitatAssetServer.cs
+++ b/Assets/Scripts/HabitatAssetServer.cs
@@ -1,0 +1,22 @@
+/// <summary>
+/// This static class configures the Unity addressables system.
+/// 
+/// The addressables system can reference static variables at initialization.
+/// This is done via profile variables. See https://docs.unity3d.com/Packages/com.unity.addressables@1.18/manual/AddressableAssetsProfiles.html. 
+/// Therefore, the static variables 'HabitatAssetServer.Address' and 'HabitatAssetServer.Port' must be set before calling any addressables API.
+/// See 'AddressablesEditor' for implementation.
+/// </summary>
+public static class HabitatAssetServer
+{
+    /// <summary>
+    /// Address where to find the remote addressable content.
+    /// Must be set before using any addressable API.
+    /// </summary>
+    public static string Address = "127.0.0.1";
+    
+    /// <summary>
+    /// Port where to find the remote addressable content.
+    /// Must be set before using any addressable API.
+    /// </summary>
+    public static string Port = "9999";
+}

--- a/Assets/Scripts/HabitatAssetServer.cs.meta
+++ b/Assets/Scripts/HabitatAssetServer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b24ba6b981e2c99f3b13014c5a622c7f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/NetworkClient.cs
+++ b/Assets/Scripts/NetworkClient.cs
@@ -30,6 +30,8 @@ public class NetworkClient : IUpdatable
 {
     const float CLIENT_STATE_SEND_FREQUENCY = 0.1f;
 
+    const bool IS_HTTPS = false;
+
     public class FlagObject
     {
         private bool flag = false;
@@ -91,14 +93,26 @@ public class NetworkClient : IUpdatable
         _connectionParams = ConnectionParameters.GetConnectionParameters(Application.absoluteURL);
         var serverHostnameOverride = ConnectionParameters.GetServerHostname(_connectionParams);
         var serverPortRange = ConnectionParameters.GetServerPortRange(_connectionParams);
+        var assetHostname = ConnectionParameters.GetAssetHostname(_connectionParams);
+        var assetPort = ConnectionParameters.GetAssetPort(_connectionParams);
+        var assetPath = ConnectionParameters.GetAssetPath(_connectionParams);
+
+        // Set remote asset server location. See 'HabitatAssetServer'.
+        // These static variables are interpreted by the Addressables system the first time it is used.
+        if (assetHostname != null)
+            HabitatAssetServer.Address = assetHostname;
+        if (assetPort != null)
+            HabitatAssetServer.Port = assetPort.ToString();
+        if (assetPath != null)
+            HabitatAssetServer.Path = assetPath;
+        HabitatAssetServer.Protocol = IS_HTTPS ? "https" : "http";
 
         if (serverPortRange == null)
         {
             serverPortRange = (defaultServerPort, defaultServerPort);
         }
 
-        bool isHttps = false;
-        string wsProtocol = isHttps ? "wss" : "ws";
+        string wsProtocol = IS_HTTPS ? "wss" : "ws";
         // Set up server hostnames and port.
         string[] serverLocations = serverHostnameOverride != null ? 
                                         new[]{serverHostnameOverride} : 

--- a/Assets/Scripts/NetworkClient.cs
+++ b/Assets/Scripts/NetworkClient.cs
@@ -282,7 +282,7 @@ public class NetworkClient : IUpdatable
                 {
                     // This was a short connection. Disconnected most likely due to server already having a client.
                     _disconnectReason = "Server is busy!";
-                    _delayReconnect = _serverURLs.Count == 1 ? 10.0f : 3.0f;
+                    _delayReconnect = _serverURLs.Count == 1 ? 5.0f : 2.0f;
                 }
             }
         };

--- a/Assets/Scripts/Tests/EditMode/EditMode.asmdef
+++ b/Assets/Scripts/Tests/EditMode/EditMode.asmdef
@@ -4,7 +4,8 @@
     "references": [
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",
-        "Habitat"
+        "Habitat",
+        "Habitat.Editor"
     ],
     "includePlatforms": [
         "Editor"

--- a/Assets/Scripts/Tests/EditMode/TestAddressablesEditor.cs
+++ b/Assets/Scripts/Tests/EditMode/TestAddressablesEditor.cs
@@ -1,0 +1,40 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Habitat.Editor;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+
+namespace Habitat.Tests.EditMode
+{
+    
+    public class TestAddressablesEditor
+    {
+        [Test]
+        public void TestCreateLabelShortName()
+        {
+            for (uint counter = 0u; counter < 26u; ++counter)
+            {
+                string labelName = AddressablesEditor.CreateShortLabelName(counter);
+                Assert.IsTrue(labelName.Length == 1);
+                Assert.IsTrue(char.IsLower(labelName[0]));
+            }
+            for (uint counter = 27u; counter < 52u; ++counter)
+            {
+                string labelName = AddressablesEditor.CreateShortLabelName(counter);
+                Assert.IsTrue(labelName.Length == 1);
+                Assert.IsTrue(char.IsUpper(labelName[0]));
+            }
+            for (uint counter = 53u; counter < 10000u; ++counter)
+            {
+                string labelName = AddressablesEditor.CreateShortLabelName(counter);
+                Assert.IsTrue(labelName.Length > 1);
+                Assert.IsTrue(char.IsLetter(labelName[0]));
+                for (int i = 1; i < labelName.Length; ++i)
+                {
+                    Assert.IsTrue(char.IsDigit(labelName[i]));
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Tests/EditMode/TestAddressablesEditor.cs.meta
+++ b/Assets/Scripts/Tests/EditMode/TestAddressablesEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ab3b1020bacdbc42490cf83062cfa220
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Tests/EditMode/TestConnectionParameters.cs
+++ b/Assets/Scripts/Tests/EditMode/TestConnectionParameters.cs
@@ -142,6 +142,62 @@ namespace Habitat.Tests.EditMode
         }
 
         [Test]
+        public void TestGetAssetHostname()
+        {
+            string url;
+            string host;
+            Dictionary<string, string> parameters;
+
+            // Valid cases.
+            LogAssert.ignoreFailingMessages = false;
+
+            // Canonical case.
+            url = "test?asset_hostname=HOST&asset_port=1111&test=true";
+            parameters = ConnectionParameters.GetConnectionParameters(url);
+            host = ConnectionParameters.GetAssetHostname(parameters);
+            Assert.AreEqual(host, "HOST");
+
+            // No hostname.
+            url = "test?test=test";
+            parameters = ConnectionParameters.GetConnectionParameters(url);
+            host = ConnectionParameters.GetAssetHostname(parameters);
+            Assert.AreEqual(host, null);
+
+            // No parameter.
+            url = "test";
+            parameters = ConnectionParameters.GetConnectionParameters(url);
+            host = ConnectionParameters.GetAssetHostname(parameters);
+            Assert.AreEqual(host, null);
+
+            // IP hostname.
+            url = "test?asset_hostname=127.0.0.1";
+            parameters = ConnectionParameters.GetConnectionParameters(url);
+            host = ConnectionParameters.GetAssetHostname(parameters);
+            Assert.AreEqual(host, "127.0.0.1");
+
+            // Null input
+            host = ConnectionParameters.GetAssetHostname(null);
+            Assert.AreEqual(host, null);
+
+            // Invalid cases.
+            LogAssert.ignoreFailingMessages = true;
+
+            // Hostname with port. This is considered invalid.
+            url = "test?asset_hostname=127.0.0.1:1111";
+            parameters = ConnectionParameters.GetConnectionParameters(url);
+            host = ConnectionParameters.GetAssetHostname(parameters);
+            Assert.AreEqual(host, null);
+
+            // Invalid hostname.
+            url = "test?asset_hostname=test<>";
+            parameters = ConnectionParameters.GetConnectionParameters(url);
+            host = ConnectionParameters.GetAssetHostname(parameters);
+            Assert.AreEqual(host, null);
+
+            LogAssert.ignoreFailingMessages = false;
+        }
+
+        [Test]
         public void TestTryParsePortString()
         {
             int port;
@@ -264,6 +320,106 @@ namespace Habitat.Tests.EditMode
             parameters = ConnectionParameters.GetConnectionParameters(url);
             portRange = ConnectionParameters.GetServerPortRange(parameters);
             Assert.AreEqual(portRange, null);
+
+            LogAssert.ignoreFailingMessages = false;
+        }
+
+        [Test]
+        public void TestGetAssetPort()
+        {
+            string url;
+            int? port;
+            Dictionary<string, string> parameters;
+
+            // Valid cases.
+            LogAssert.ignoreFailingMessages = false;
+
+            // Canonical asset_port.
+            url = "test?asset_hostname=HOST&asset_port=2222&test=true";
+            parameters = ConnectionParameters.GetConnectionParameters(url);
+            port = ConnectionParameters.GetAssetPort(parameters);
+            Assert.AreEqual(port.Value, 2222);
+
+            // No port.
+            url = "test?test=test";
+            parameters = ConnectionParameters.GetConnectionParameters(url);
+            port = ConnectionParameters.GetAssetPort(parameters);
+            Assert.AreEqual(port, null);
+
+            // No parameter.
+            url = "test";
+            parameters = ConnectionParameters.GetConnectionParameters(url);
+            port = ConnectionParameters.GetAssetPort(parameters);
+            Assert.AreEqual(port, null);
+
+            // Null input
+            port = ConnectionParameters.GetAssetPort(null);
+            Assert.AreEqual(port, null);
+
+            // Invalid cases.
+            LogAssert.ignoreFailingMessages = true;
+
+            // Invalid port.
+            url = "test?asset_port=test";
+            parameters = ConnectionParameters.GetConnectionParameters(url);
+            port = ConnectionParameters.GetAssetPort(parameters);
+            Assert.AreEqual(port, null);
+
+            // Negative port.
+            url = "test?asset_port=-100";
+            parameters = ConnectionParameters.GetConnectionParameters(url);
+            port = ConnectionParameters.GetAssetPort(parameters);
+            Assert.AreEqual(port, null);
+
+            // Port > 65535.
+            url = "test?asset_port=1000000";
+            parameters = ConnectionParameters.GetConnectionParameters(url);
+            port = ConnectionParameters.GetAssetPort(parameters);
+            Assert.AreEqual(port, null);
+
+            LogAssert.ignoreFailingMessages = false;
+        }
+
+        [Test]
+        public void TestGetAssetPath()
+        {
+            string url;
+            string path;
+            Dictionary<string, string> parameters;
+
+            // Valid cases.
+            LogAssert.ignoreFailingMessages = false;
+
+            // Canonical case.
+            url = "test?asset_path=test/test&asset_port=1111&test=true";
+            parameters = ConnectionParameters.GetConnectionParameters(url);
+            path = ConnectionParameters.GetAssetPath(parameters);
+            Assert.AreEqual(path, "test/test");
+
+            // No path.
+            url = "test?test=test";
+            parameters = ConnectionParameters.GetConnectionParameters(url);
+            path = ConnectionParameters.GetAssetPath(parameters);
+            Assert.AreEqual(path, null);
+
+            // No parameter.
+            url = "test";
+            parameters = ConnectionParameters.GetConnectionParameters(url);
+            path = ConnectionParameters.GetAssetPath(parameters);
+            Assert.AreEqual(path, null);
+
+            // Null input
+            path = ConnectionParameters.GetAssetPath(null);
+            Assert.AreEqual(path, null);
+
+            // Invalid cases.
+            LogAssert.ignoreFailingMessages = true;
+
+            // Invalid path.
+            url = "test?asset_path=test\\test";
+            parameters = ConnectionParameters.GetConnectionParameters(url);
+            path = ConnectionParameters.GetAssetPath(parameters);
+            Assert.AreEqual(path, null);
 
             LogAssert.ignoreFailingMessages = false;
         }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "com.endel.nativewebsocket": "https://github.com/endel/NativeWebSocket.git#upm",
     "com.siccity.gltfutility": "https://github.com/siccity/gltfutility.git",
+    "com.unity.addressables": "1.21.20",
     "com.unity.feature.vr": "1.0.0",
     "com.unity.ide.visualstudio": "2.0.21",
     "com.unity.learn.iet-framework": "3.1.3",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -15,6 +15,20 @@
         "com.unity.nuget.newtonsoft-json": "2.0.0"
       }
     },
+    "com.unity.addressables": {
+      "version": "1.21.20",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.scriptablebuildpipeline": "1.21.22",
+        "com.unity.modules.assetbundle": "1.0.0",
+        "com.unity.modules.imageconversion": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0",
+        "com.unity.modules.unitywebrequest": "1.0.0",
+        "com.unity.modules.unitywebrequestassetbundle": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.burst": {
       "version": "1.8.7",
       "depth": 1,
@@ -117,6 +131,13 @@
         "com.unity.render-pipelines.core": "14.0.8",
         "com.unity.shadergraph": "14.0.8"
       }
+    },
+    "com.unity.scriptablebuildpipeline": {
+      "version": "1.21.22",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
     },
     "com.unity.searcher": {
       "version": "4.9.2",

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -5,10 +5,10 @@ EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Scenes:
-  - enabled: 1
+  - enabled: 0
     path: Assets/Scenes/PlayerVR.unity
     guid: a325b0886d7964109b67d826ec5c503b
-  - enabled: 0
+  - enabled: 1
     path: Assets/Scenes/PlayerMouseKeyboard.unity
     guid: 6780099784da3bc7cb1c7bddc2e221d0
   m_configObjects:


### PR DESCRIPTION
### Context:

This changeset adds the [Addressables](https://docs.unity3d.com/Manual/com.unity.addressables.html) packages to the project to replace the old [Resources](https://docs.unity3d.com/ScriptReference/Resources.html) workflow.

This allows for loading local and remote resources at runtime using standardized keys (called `addresses`).

Our addresses are Habitat data paths (e.g. `data/dataset/blob.glb`).

---

### How it works:
Editor:
* Dev exports Habitat data in a format usable by Unity using [this code](https://github.com/facebookresearch/habitat-lab/pull/1886) in `habitat-lab`.
* Dev imports Habitat data using the `Habitat / Import Habitat Data` menu item.
* Dev builds the addressables using the `Habitat / Build Catalog` menu item.

Build-time:
* Addressable assets are procedurally generated (on gitignore).
    * Normally, these would be manually authored and versioned. Our use case is atypical.
* Two [groups](https://docs.unity3d.com/Packages/com.unity.addressables@1.18/manual/Groups.html) are created: `local` and `remote`.
* [Labels](https://docs.unity3d.com/Packages/com.unity.addressables@1.19/manual/Labels.html) are assigned to each asset based on dependencies. This is done using the `metadata.json` file generated in [this PR](https://github.com/facebookresearch/habitat-lab/pull/1886).
    * For example, if a window is used by 5 scenes, 5 labels will be applied to it.
* One asset bundle is created for each combination of label.
* All `local` assets are stored automagically in the project cache.
* All `remote` bundles are exported to `/ServerData`. This folder can be copied to a remote server for delivery.
    * One subfolder is created for each build target (`WebGL`, `Android`, ...). Currently, we only support one at a time.

Runtime:
* Remote server parameters are parsed and assigned to static variables.
* These variables are interpolated by addressables the first time the API is used. A connection to the remote server is established.
* When the Unity client received a `gfx-replay` keyframe, it interprets asset paths as addresses and loads it asynchronously.
* _If running from the Editor, a remote server is not required. You can simulate a real setup by changing [these options](https://docs.unity3d.com/Packages/com.unity.addressables@1.1/manual/AddressableAssetsDevelopmentCycle.html)._

---

### This changeset includes:
* Addressables.
* Editor tools for importing addressables.
* Asynchronous content loading.
* Content server specification.

Notes:
* Depends on: https://github.com/facebookresearch/habitat-lab/pull/1886
* Not fully tested on Android yet.
* In the future, the process will be streamlined, guided and sanity-checked (via Editor tools).