### PR TITLE
Add loading bar.

### DIFF
--- a/Assets/Scripts/AppMouseKeyboard.cs
+++ b/Assets/Scripts/AppMouseKeyboard.cs
@@ -32,6 +32,7 @@ public class AppMouseKeyboard : MonoBehaviour
     LoadingEffectHandler _loadingEffectHandler;
     CameraTransformHandler _cameraTransformHandler;
     TextRenderer _textRenderer;
+    LoadingScreenOverlay _loadingScreenOverlay;
 
     // IClientStateProducers
     InputTrackerMouse _inputTrackerMouse;
@@ -52,6 +53,8 @@ public class AppMouseKeyboard : MonoBehaviour
         _loadingEffectHandler = new LoadingEffectHandler();
         _cameraTransformHandler = new CameraTransformHandler(_camera);
         _textRenderer = new TextRenderer();
+        _loadingScreenOverlay = new LoadingScreenOverlay(_camera);
+        
         var keyframeMessageConsumers = new IKeyframeMessageConsumer[]
         {
             _serverKeyframeIdHandler,
@@ -59,6 +62,7 @@ public class AppMouseKeyboard : MonoBehaviour
             _loadingEffectHandler,
             _cameraTransformHandler,
             _textRenderer,
+            _loadingScreenOverlay,
         };
 
         // Initialize IClientStateProducers.

--- a/Assets/Scripts/GfxReplayPlayer.cs
+++ b/Assets/Scripts/GfxReplayPlayer.cs
@@ -271,26 +271,8 @@ public class GfxReplayPlayer : IUpdatable
                 
                 _instanceDictionary[key].Destroy();
             }
-            _coroutines.StartCoroutine(ReleaseUnusedMemory(
-                // Wait for memory clean-up to be finished before executing KeyframePostUpdate()
-                () => {KeyframePostUpdate(keyframe);})
-            );
+            _coroutines.StartCoroutine(ReleaseUnusedMemory());
             Debug.Log($"Processed {keyframe.deletions.Length} deletions!");
-        }
-        else
-        {
-            KeyframePostUpdate(keyframe);
-        }
-    }
-
-    void KeyframePostUpdate(KeyframeData keyframe)
-    {
-        if (keyframe.message != null)
-        {
-            foreach (var messageConsumer in _messageConsumers)
-            {
-                messageConsumer.PostProcessMessage(keyframe.message);
-            }
         }
     }
 
@@ -328,9 +310,6 @@ public class GfxReplayPlayer : IUpdatable
         }
 
         // Invoke callback.
-        if (callback != null)
-        {
-            callback.Invoke();
-        }
+        callback?.Invoke();
     }
 }

--- a/Assets/Scripts/IKeyframeMessageConsumer.cs
+++ b/Assets/Scripts/IKeyframeMessageConsumer.cs
@@ -8,11 +8,4 @@ public interface IKeyframeMessageConsumer : IUpdatable
     /// </summary>
     /// <param name="message">'Message' portion of a keyframe.</param>
     public void ProcessMessage(Message message);
-
-    /// <summary>
-    /// Process a message after the keyframe has been processed.
-    /// Use for actions that must happen after the assets are loaded.
-    /// </summary>
-    /// <param name="message">'Message' portion of a keyframe.</param>
-    public void PostProcessMessage(Message message) {}
 }

--- a/Assets/Scripts/LoadProgressTracker.cs
+++ b/Assets/Scripts/LoadProgressTracker.cs
@@ -1,0 +1,147 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Assertions;
+
+/// <summary>
+/// Singleton that tracks assets that are currently being loaded.
+/// Provides global loading events and statistics. 
+/// </summary>
+public class LoadProgressTracker
+{
+    static LoadProgressTracker _instance = null;
+    HashSet<GfxReplayInstance> _loadingInstances = new();
+    float _progress = 1.0f;
+    uint _successCount = 0;
+    uint _failureCount = 0;
+
+    /// <summary>
+    /// Get the LoadProgressTracker singleton.
+    /// </summary>
+    public static LoadProgressTracker Instance
+    {
+        get
+        {
+            if (_instance == null)
+            {
+                _instance = new LoadProgressTracker();
+            }
+            return _instance;
+        }
+    }
+
+    /// <summary>
+    /// Event that is emitted when the first asset is being loaded.
+    /// </summary>
+    public event System.Action OnLoadStarted;
+
+    /// <summary>
+    /// Event that is emitted when the last asset has been loaded (or failed to load).
+    /// </summary>
+    public event System.Action OnLoadFinished;
+
+    /// <summary>
+    /// Estimate the current loading progress.
+    /// </summary>
+    /// <returns>A value between 0 and 1.</returns>
+    public float EstimateProgress()
+    {
+        if (_loadingInstances.Count == 0)
+        {
+            _progress = 1.0f;
+        }
+        else
+        {
+            _progress = 0.0f;
+            foreach (var instance in _loadingInstances)
+            {
+                _progress += instance.LoadingProgress;
+            }
+        }
+        return _progress;
+    }
+
+    /// <summary>
+    /// Whether at least one asset is being loaded.
+    /// </summary>
+    public bool IsLoading { get { return _loadingInstances.Count > 0; }}
+
+    /// <summary>
+    /// Number of assets that are being loaded.
+    /// </summary>
+    public int LoadingInstanceCount { get { return _loadingInstances.Count; }}
+
+    /// <summary>
+    /// Number of assets that were successfully loaded since starting the client.
+    /// </summary>
+    public uint SuccessCount { get { return _successCount; }}
+
+    /// <summary>
+    /// Number of assets that were unsuccessfully loaded since starting the client.
+    /// </summary>
+    public uint FailureCount { get { return _failureCount; }}
+
+    /// <summary>
+    /// Monitor an unloaded GfxReplayInstance.
+    /// </summary>
+    public void TrackInstance(GfxReplayInstance instance)
+    {
+        instance.OnLoadStarted += LoadStarted;
+        instance.OnLoadSucceeded += LoadSucceeded;
+        instance.OnLoadFailed += LoadFailed;
+        instance.OnInstanceDestroyed += InstanceDestroyed;
+    }
+
+    void UntrackInstance(GfxReplayInstance instance)
+    {
+        instance.OnLoadStarted -= LoadStarted;
+        instance.OnLoadSucceeded -= LoadSucceeded;
+        instance.OnLoadFailed -= LoadFailed;
+        instance.OnInstanceDestroyed -= InstanceDestroyed;
+    }
+
+    void LoadStarted(GfxReplayInstance sender)
+    {
+        AddInstance(sender);
+    }
+
+    void LoadSucceeded(GfxReplayInstance sender)
+    {
+        ++_successCount;
+        RemoveInstance(sender);
+    }
+
+    void LoadFailed(GfxReplayInstance sender)
+    {
+        ++_failureCount;
+        RemoveInstance(sender);
+    }
+
+    void InstanceDestroyed(GfxReplayInstance sender)
+    {
+        RemoveInstance(sender);
+    }
+
+    void AddInstance(GfxReplayInstance instance)
+    {
+        if (_loadingInstances.Count == 0)
+        {
+            OnLoadStarted?.Invoke();
+        }
+        _loadingInstances.Add(instance);
+    }
+
+    void RemoveInstance(GfxReplayInstance instance)
+    {
+        int previousCount = _loadingInstances.Count;
+        if (_loadingInstances.Contains(instance))
+        {
+            _loadingInstances.Remove(instance);
+        }
+        if (previousCount == 1 && _loadingInstances.Count == 0)
+        {
+            OnLoadFinished?.Invoke();
+        }
+        UntrackInstance(instance);
+    }
+}

--- a/Assets/Scripts/LoadProgressTracker.cs.meta
+++ b/Assets/Scripts/LoadProgressTracker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b851b4d8d0c4e1c93a3fafe75041ece8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/LoadingEffectHandler.cs
+++ b/Assets/Scripts/LoadingEffectHandler.cs
@@ -1,10 +1,17 @@
 using System.Collections;
 using UnityEngine;
 
+/// <summary>
+/// Effect that fades the scene to black, using fog, when a scene is being loaded.
+/// Works both in traditional interfaces and VR.
+/// </summary>
 public class LoadingEffectHandler : IKeyframeMessageConsumer
 {
+    private LoadProgressTracker _loadProgressTracker;
     Coroutine _sceneChangeCoroutine = null;
     CoroutineContainer _coroutines;
+    bool _changingScene = false;
+    bool _loading = false;
 
     public LoadingEffectHandler()
     {
@@ -15,9 +22,15 @@ public class LoadingEffectHandler : IKeyframeMessageConsumer
         RenderSettings.fogColor = Color.black;
         RenderSettings.fog = false;
         RenderSettings.fogDensity = 0.0f;
+
+        _loadProgressTracker = LoadProgressTracker.Instance;
+        _loadProgressTracker.OnLoadStarted += LoadStarted;
+        _loadProgressTracker.OnLoadFinished += LoadFinished;
     }
 
-    public void Update() {}
+    public void Update()
+    {
+    }
 
     public void OnSceneChangeBegin()
     {
@@ -53,23 +66,31 @@ public class LoadingEffectHandler : IKeyframeMessageConsumer
         RenderSettings.fog = false;
     }
 
-    static float EaseInCubic(float x) {
-        return x * x * x;
-    }
-
     public void ProcessMessage(Message message)
     {
         if (message.sceneChanged)
+        {
+            _changingScene = true;
+        }
+    }
+
+    void LoadStarted()
+    {
+        _loading = true;
+        if (_changingScene)
         {
             OnSceneChangeBegin();
         }
     }
 
-    public void PostProcessMessage(Message message)
+    void LoadFinished()
     {
-        if (message.sceneChanged)
-        {
-            OnSceneChangeEnd();
-        }
+        _loading = false;
+        _changingScene = false;
+        OnSceneChangeEnd();
+    }
+
+    static float EaseInCubic(float x) {
+        return x * x * x;
     }
 }

--- a/Assets/Scripts/LoadingScreenOverlay.cs
+++ b/Assets/Scripts/LoadingScreenOverlay.cs
@@ -1,0 +1,110 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Assertions;
+
+public class LoadingScreenOverlay : IKeyframeMessageConsumer
+{
+    /// <summary>
+    /// Overlay, with a progress bar, that shows up when content is being loaded.
+    /// </summary>
+    class Overlay : MonoBehaviour
+    {
+        bool _initialized = false;
+        Camera _camera = null;
+        bool _visible = false;
+        float _progress = 0.0f;
+
+        public void Initialize(Camera camera)
+        {
+            _initialized = true;
+            _camera = camera;
+        }
+
+        public void UpdateState(bool visible, float progress = 0.0f)
+        {
+            _visible = visible;
+            _progress = progress;
+        }
+
+        public bool Visible { get { return _visible; }}
+
+        void OnGUI()
+        {
+            if (!_visible || !_initialized)
+            {
+                return;
+            }
+
+            int width = _camera.pixelWidth;
+            int height = _camera.pixelHeight;
+            const int progressBarHeight = 32;
+            int progressBarWidth = width / 2;
+            int progressBarXOffset = width / 4;
+            int progressBarYOffset = (height / 2) - (progressBarHeight / 2);
+
+            GUI.color = Color.white;
+            GUILayout.Window(
+                7,
+                new Rect(progressBarXOffset,progressBarYOffset,progressBarWidth,progressBarHeight),
+                WindowUpdate,
+                $"Loading ({_progress:F2})");
+        }
+
+        void WindowUpdate(int windowId)
+        {
+            GUILayout.BeginVertical();
+            GUI.color = Color.white;
+            GUILayout.HorizontalSlider(_progress, 0.0f, 1.0f);
+            GUILayout.EndVertical();
+        }
+    }
+
+    private Overlay _overlay;
+    private LoadProgressTracker _loadProgressTracker;
+    private bool _loading = false;
+    private bool _changingScene = false;
+
+    public LoadingScreenOverlay(Camera camera)
+    {
+        _loadProgressTracker = LoadProgressTracker.Instance;
+        _overlay = new GameObject("LoadingScreenOverlay").AddComponent<Overlay>();
+        _overlay.Initialize(camera);
+
+        _loadProgressTracker.OnLoadStarted += LoadStarted;
+        _loadProgressTracker.OnLoadFinished += LoadFinished;
+    }
+
+    public void ProcessMessage(Message message)
+    {
+        if (message.sceneChanged)
+        {
+            _changingScene = true;
+        }
+    }
+
+    public void Update()
+    {
+        // Show the loading bar overlay if the scene has changed, and if loading is active.
+        // Avoid showing it for single item loads.
+        if (_loading && _changingScene)
+        {
+            _overlay.UpdateState(visible: true, progress: _loadProgressTracker.EstimateProgress());
+        }
+        else
+        {
+            _overlay.UpdateState(visible: false);
+        }
+    }
+
+    void LoadStarted()
+    {
+        _loading = true;
+    }
+
+    void LoadFinished()
+    {
+        _loading = false;
+        _changingScene = false;
+    }
+}

--- a/Assets/Scripts/LoadingScreenOverlay.cs.meta
+++ b/Assets/Scripts/LoadingScreenOverlay.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eba353356c303ed0095a3a8008fdaa0f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/TextRenderer.cs
+++ b/Assets/Scripts/TextRenderer.cs
@@ -14,7 +14,7 @@ public class TextRenderer : IKeyframeMessageConsumer
 
         public void OnGUI()
         {
-            if (texts == null)
+            if (texts == null || LoadProgressTracker.Instance.IsLoading)
             {
                 return;
             }
@@ -44,6 +44,4 @@ public class TextRenderer : IKeyframeMessageConsumer
     {
         _textRenderer.texts = message.texts?.ToArray();
     }
-
-    public void PostProcessMessage(Message message) {}
 }


### PR DESCRIPTION
This changeset adds a loading bar that shows up when a scene changes, and items are being loaded.
It does not show up if individual items are being loaded.

A singleton, `LoadProgressTracker`, was added to act as a single source of truth for all information related to loading. It emits events and produces statistics (that will be sent to the server).

https://github.com/0mdc/siro_hitl_unity_client/assets/110583667/4eff9091-0f15-4b1d-b0a2-c66ba4418f5c
