### PR TITLE
Send connection parameters at every new connection.

### DIFF
--- a/Assets/Scripts/NetworkClient.cs
+++ b/Assets/Scripts/NetworkClient.cs
@@ -245,6 +245,7 @@ public class NetworkClient : IUpdatable
 
             Debug.Log("Connected to: " + url);
             _recentConnectionMessageCount = 0;
+            _firstTransmission = true;
 
             // Reset the server keyframe ID to avoid leaking ID from a previous session
             _serverKeyframeIdHandler.Reset();
@@ -406,7 +407,6 @@ public class NetworkClient : IUpdatable
                 // Update state after first successful transmission.
                 if (_firstTransmission && task.Status == TaskStatus.RanToCompletion)
                 {
-                    _clientState.connection_params_dict = null;
                     _firstTransmission = false;
                 }
             }


### PR DESCRIPTION
We send the connection parameters (query args) the first frame the client connects to a server.

This changes the behaviour so that every new connection gets the connection parameters. This fixes the following:
* Eliminates flakiness due to clients being rejected by occupied servers.
* Simplifies testing. It is common to keep a client open while iterating on server code.