### PR TITLE
Add loading client state.

### DIFF
--- a/Assets/Scripts/ClientState.cs
+++ b/Assets/Scripts/ClientState.cs
@@ -11,6 +11,7 @@ public class ClientState
     public MouseInputData mouse;
     public Dictionary<string, string> connection_params_dict;
     public int? recentServerKeyframeId = null;
+    public bool isLoading;
 }
 
 [Serializable]

--- a/Assets/Scripts/InputTrackerKeyboard.cs
+++ b/Assets/Scripts/InputTrackerKeyboard.cs
@@ -135,6 +135,12 @@ public class InputTrackerKeyboard : IClientStateProducer
 
     public void Update()
     {
+        // Don't update if loading.
+        if (LoadProgressTracker.Instance.IsLoading)
+        {
+            return;
+        }
+
         // Record all keys that were pressed or released since the last OnEndFrame() call.
         // Note that multiple Unity frames may occur during that time.
         for (int i = 0; i < KEY_COUNT; i++)

--- a/Assets/Scripts/InputTrackerMouse.cs
+++ b/Assets/Scripts/InputTrackerMouse.cs
@@ -31,6 +31,12 @@ public class InputTrackerMouse : IClientStateProducer
 
     public void Update()
     {
+        // Don't update if loading.
+        if (LoadProgressTracker.Instance.IsLoading)
+        {
+            return;
+        }
+
         // Record all mouse actions that occurred OnEndFrame() call.
         // Note that multiple Unity frames may occur during that time.
         int mouseIndex = 0;

--- a/Assets/Scripts/NetworkClient.cs
+++ b/Assets/Scripts/NetworkClient.cs
@@ -351,6 +351,8 @@ public class NetworkClient : IUpdatable
 
     void UpdateClientState()
     {
+        _clientState.isLoading = LoadProgressTracker.Instance.IsLoading;
+        
         if (_clientStateProducers == null)
         {
             return;


### PR DESCRIPTION
This change adds a `isLoading` client state to signal the server that the client is loading.

This also blocks user input when loading.

Relates to:
* https://github.com/facebookresearch/habitat-lab/pull/1955