### PR TITLE
Standardize connectionParamsDict variable name.

### DIFF
--- a/Assets/Scripts/ClientState.cs
+++ b/Assets/Scripts/ClientState.cs
@@ -9,7 +9,7 @@ public class ClientState
     public AvatarData avatar;
     public ButtonInputData input;
     public MouseInputData mouse;
-    public Dictionary<string, string> connection_params_dict;
+    public Dictionary<string, string> connectionParamsDict;
     public int? recentServerKeyframeId = null;
 }
 

--- a/Assets/Scripts/NetworkClient.cs
+++ b/Assets/Scripts/NetworkClient.cs
@@ -388,7 +388,7 @@ public class NetworkClient : IUpdatable
                 // Only include connection parameters in the first successful transmission.
                 if (_firstTransmission && _connectionParams?.Count > 0)
                 {
-                    _clientState.connection_params_dict = _connectionParams;
+                    _clientState.connectionParamsDict = _connectionParams;
                 }
 
                 // Serialize ClientState to JSON.


### PR DESCRIPTION
This renames `connection_params_dict` to standardize with other comms variables.