### PR TITLE
Add picture-in-picture viewports.

### DIFF
--- a/Assets/Scripts/AppMouseKeyboard.cs
+++ b/Assets/Scripts/AppMouseKeyboard.cs
@@ -33,6 +33,7 @@ public class AppMouseKeyboard : MonoBehaviour
     CameraTransformHandler _cameraTransformHandler;
     TextRenderer _textRenderer;
     LoadingScreenOverlay _loadingScreenOverlay;
+    ViewportHandler _viewportHandler;
 
     // IClientStateProducers
     InputTrackerMouse _inputTrackerMouse;
@@ -54,6 +55,7 @@ public class AppMouseKeyboard : MonoBehaviour
         _cameraTransformHandler = new CameraTransformHandler(_camera);
         _textRenderer = new TextRenderer();
         _loadingScreenOverlay = new LoadingScreenOverlay(_camera);
+        _viewportHandler = new ViewportHandler(_camera);
         
         var keyframeMessageConsumers = new IKeyframeMessageConsumer[]
         {
@@ -63,6 +65,7 @@ public class AppMouseKeyboard : MonoBehaviour
             _cameraTransformHandler,
             _textRenderer,
             _loadingScreenOverlay,
+            _viewportHandler,
         };
 
         // Initialize IClientStateProducers.

--- a/Assets/Scripts/Keyframe.cs
+++ b/Assets/Scripts/Keyframe.cs
@@ -114,6 +114,7 @@ public class Message
     public List<TextMessage> texts;
     public AbsTransform camera;
     public int serverKeyframeId;
+    public Dictionary<int, ViewportProperties> viewports;
 }
 
 [Serializable]
@@ -140,4 +141,12 @@ public class TextMessage
 {
     public string text;
     public List<float> position;
+}
+
+[Serializable]
+public class ViewportProperties
+{
+    public bool? enabled;
+    public float[] rect;
+    public AbsTransform camera;
 }

--- a/Assets/Scripts/ViewportHandler.cs
+++ b/Assets/Scripts/ViewportHandler.cs
@@ -79,6 +79,8 @@ public class ViewportHandler : IKeyframeMessageConsumer
                 }
             }
 
+            // Rect format: X, Y, Width, Height.
+            // The values are in normalized screen cordinates (between 0 and 1).
             if (properties.rect?.Length == 4)
             {
                 var rect = properties.rect;

--- a/Assets/Scripts/ViewportHandler.cs
+++ b/Assets/Scripts/ViewportHandler.cs
@@ -1,0 +1,94 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Manages application viewports.
+/// Viewports are screen regions rendering with a camera.
+/// The default viewport has the ID -1.
+/// </summary>
+public class ViewportHandler : IKeyframeMessageConsumer
+{
+    public struct Viewport
+    {
+        public Camera camera;
+    }
+
+    Dictionary<int, Viewport> _viewports = new();
+
+    Camera _mainCamera;
+
+    int DEFAULT_LAYERS = LayerMask.NameToLayer("Default") | LayerMask.NameToLayer("UI");
+
+    public ViewportHandler(Camera mainCamera)
+    {
+        _mainCamera = mainCamera;
+        _viewports.Add(-1, new Viewport()
+        {
+            camera = mainCamera
+        });
+    }
+
+    public void ProcessMessage(Message message)
+    {
+        Dictionary<int, ViewportProperties> viewportUpdates = message.viewports;
+
+        foreach (var pair in _viewports)
+        {
+            if (pair.Key != -1)
+            {
+                Camera cam = pair.Value.camera;
+                cam.enabled = false;
+            }
+        }
+
+        if (viewportUpdates == null)
+        {
+            return;
+        }
+        foreach (var pair in viewportUpdates)
+        {
+            int key = pair.Key;
+            if (!_viewports.ContainsKey(key))
+            {
+                // Clone the main camera.
+                GameObject container = GameObject.Instantiate(_mainCamera.gameObject);
+                container.name = $"Viewport {key}";
+                Camera newCamera = container.GetComponent<Camera>();
+                newCamera.tag = "Untagged"; // Remove MainCamera tag.
+                newCamera.GetComponent<AudioListener>().enabled = false; // Disable audio.
+                _viewports[key] = new Viewport()
+                {
+                    camera = newCamera
+                };
+            }
+
+            ViewportProperties properties = pair.Value;
+            Viewport viewport = _viewports[key];
+            Camera camera = viewport.camera;
+
+            if (key != -1)
+            {
+                camera.enabled = properties.enabled.GetValueOrDefault();
+                if (camera.enabled)
+                {
+                    if (properties.camera?.translation?.Count == 3 && properties.camera?.rotation?.Count == 4) {
+                        camera.transform.position = CoordinateSystem.ToUnityVector(properties.camera.translation);
+                        camera.transform.rotation = CoordinateSystem.ToUnityQuaternion(properties.camera.rotation);
+                    }
+                }
+            }
+
+            if (properties.rect?.Length == 4)
+            {
+                var rect = properties.rect;
+                camera.rect = new Rect(rect[0], rect[1], rect[2], rect[3]);
+            }
+        }
+    }
+
+    void IUpdatable.Update()
+    {
+        
+    }
+}

--- a/Assets/Scripts/ViewportHandler.cs.meta
+++ b/Assets/Scripts/ViewportHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 48f4154a705c3cdfa9615a16c81cfb82
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This adds picture-in-picture viewports to the application.

Each viewport has an ID. The default viewport (main application view) has a fixed ID of `-1`.

Viewports are controlled by sending a `viewports` message, which is a map of viewport IDs and viewport properties.

Viewport creation:
1. The server sends a new viewport with an ID `X`.
2. The client does not know this viewport. It clones the main camera and creates a new viewport.

Viewport update:
1. The server sets the `enabled` property to viewport `X` to hide it.
2. The client applies all properties. The viewport is now hidden.

Depends on:
* https://github.com/facebookresearch/habitat-lab/pull/1958

https://github.com/0mdc/siro_hitl_unity_client/assets/110583667/7764e37e-1faf-421f-8ae1-eb27026ac192