### PR TITLE
Instance visibility and metadata.

### DIFF
--- a/Assets/Scripts/Keyframe.cs
+++ b/Assets/Scripts/Keyframe.cs
@@ -25,7 +25,8 @@ public class KeyframeData
     public Load[] loads;
     public RigCreation[] rigCreations;
     public CreationItem[] creations;
-    public StateUpdate[] stateUpdates;
+    public InstanceMetadataItem[] metadata;
+    public StateUpdateItem[] stateUpdates;
     public RigUpdate[] rigUpdates;
     public int[] deletions;
     public Message message;
@@ -68,17 +69,30 @@ public class Creation
 }
 
 [Serializable]
-public class StateUpdate
+public class StateUpdateItem
 {
     public int instanceKey;
-    public StateData state;
+    public StateUpdate state;
+}
 
-    [Serializable]
-    public class StateData
-    {
-        public AbsTransform absTransform;
-        public int semanticId;
-    }
+[Serializable]
+public class StateUpdate
+{
+    public AbsTransform absTransform;
+}
+
+[Serializable]
+public class InstanceMetadataItem
+{
+    public int instanceKey;
+    public InstanceMetadata metadata;
+}
+
+[Serializable]
+public class InstanceMetadata
+{
+    public int objectId;
+    public int semanticId;
 }
 
 [Serializable]
@@ -114,6 +128,7 @@ public class Message
     public List<TextMessage> texts;
     public AbsTransform camera;
     public int serverKeyframeId;
+    public Dictionary<int, ObjectProperties> objects;
     public Dictionary<int, ViewportProperties> viewports;
     public Dialog dialog;
 }
@@ -145,9 +160,17 @@ public class TextMessage
 }
 
 [Serializable]
+public class ObjectProperties
+{
+    public bool? visible;
+    public int? layer;
+}
+
+[Serializable]
 public class ViewportProperties
 {
     public bool? enabled;
+    public int[] layers;
     public float[] rect;
     public AbsTransform camera;
 }

--- a/Assets/Scripts/ViewportHandler.cs
+++ b/Assets/Scripts/ViewportHandler.cs
@@ -80,7 +80,7 @@ public class ViewportHandler : IKeyframeMessageConsumer
             }
 
             // Rect format: X, Y, Width, Height.
-            // The values are in normalized screen cordinates (between 0 and 1).
+            // The values are in normalized screen coordinates (between 0 and 1).
             if (properties.rect?.Length == 4)
             {
                 var rect = properties.rect;

--- a/Assets/Scripts/ViewportHandler.cs
+++ b/Assets/Scripts/ViewportHandler.cs
@@ -18,11 +18,21 @@ public class ViewportHandler : IKeyframeMessageConsumer
 
     Camera _mainCamera;
 
+    // TODO: Move to constants.
+    public const int FIRST_LAYER_INDEX = 8;
+    public const int LAYER_COUNT = 8;
+    public const int LAST_LAYER_INDEX = FIRST_LAYER_INDEX + LAYER_COUNT;
+
     int DEFAULT_LAYERS = LayerMask.NameToLayer("Default") | LayerMask.NameToLayer("UI");
 
     public ViewportHandler(Camera mainCamera)
     {
         _mainCamera = mainCamera;
+        _mainCamera.cullingMask = DEFAULT_LAYERS;
+        for (int layerIndex = FIRST_LAYER_INDEX; layerIndex < LAST_LAYER_INDEX; ++layerIndex)
+        {
+            _mainCamera.cullingMask |= 1 << layerIndex;
+        }
         _viewports.Add(-1, new Viewport()
         {
             camera = mainCamera
@@ -85,6 +95,17 @@ public class ViewportHandler : IKeyframeMessageConsumer
             {
                 var rect = properties.rect;
                 camera.rect = new Rect(rect[0], rect[1], rect[2], rect[3]);
+            }
+
+            if (properties.layers != null)
+            {
+                int mask = DEFAULT_LAYERS;
+                foreach (int layer in properties.layers)
+                {
+                    int layerIndex = FIRST_LAYER_INDEX + layer;
+                    mask |= 1 << layerIndex;
+                }
+                camera.cullingMask = mask;
             }
         }
     }


### PR DESCRIPTION
This changeset adds instance metadata support and object visibility.

Note that [Unity reserves the first visibility 8 layers](https://docs.unity3d.com/ScriptReference/LayerMask.html). Therefore, we offset the ones we reserve for Habitat.

Depends on:
* Latest `habitat-sim`.
* https://github.com/0mdc/siro_hitl_unity_client/pull/28
* https://github.com/facebookresearch/habitat-lab/pull/1958
* https://github.com/facebookresearch/habitat-lab/pull/1959

---

In this video, object visibility is set such as each player cannot see themselves in the first-person view.

Notice that the other player's view in the picture-in-picture viewport is correctly handled.

https://github.com/0mdc/siro_hitl_unity_client/assets/110583667/d0e7627a-0853-4aec-8dc7-8a1abba27c6b

Without object visibility support:

https://github.com/0mdc/siro_hitl_unity_client/assets/110583667/dbaac39b-95d1-44af-8d23-727c8dc5cb73

