### PR TITLE
Add ambient occlusion.

### DIFF
--- a/Assets/AmplifyOcclusion-URP.meta
+++ b/Assets/AmplifyOcclusion-URP.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a0863bd41b0a95c69ae4b503af01b058
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion.meta
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6dceddc39e0eb86fbb7c258d5366546c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Plugins.meta
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Plugins.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: b84d9762e95a6ac41ad865e2a86a83c5
+folderAsset: yes
+timeCreated: 1449343891
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Plugins/AmplifyOcclusionCommon.cs
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Plugins/AmplifyOcclusionCommon.cs
@@ -1,0 +1,386 @@
+// Amplify Occlusion 2 - Robust Ambient Occlusion for Unity
+// Copyright (c) Amplify Creations, Lda <info@amplify.pt>
+
+using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.Profiling;
+
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace AmplifyOcclusion
+{
+
+public static class AmplifyOcclusionCommon
+{
+	public static readonly int PerPixelNormalSourceCount = 4;
+	public static readonly float[] m_temporalRotations = { 60.0f, 300.0f, 180.0f, 240.0f, 120.0f, 0.0f };
+	public static readonly float[] m_spatialOffsets = { 0.0f, 0.5f, 0.25f, 0.75f };
+
+	public static void CommandBuffer_TemporalFilterDirectionsOffsets( CommandBuffer cb, uint aSampleStep )
+	{
+		float temporalRotation = AmplifyOcclusionCommon.m_temporalRotations[ aSampleStep % 6 ];
+		float temporalOffset = AmplifyOcclusionCommon.m_spatialOffsets[ ( aSampleStep / 6 ) % 4 ];
+
+		cb.SetGlobalFloat( PropertyID._AO_TemporalDirections, temporalRotation / 360.0f );
+		cb.SetGlobalFloat( PropertyID._AO_TemporalOffsets, temporalOffset );
+	}
+
+	public static Material CreateMaterialWithShaderName( string aShaderName, bool aThroughErrorMsg )
+	{
+		var shader = Shader.Find( aShaderName );
+
+		if( shader == null )
+		{
+			if( aThroughErrorMsg == true )
+			{
+				Debug.LogErrorFormat( "[AmplifyOcclusion] Cannot find shader: \"{0}\"" +
+										" Please contact support@amplify.pt", aShaderName );
+			}
+
+			return null;
+		}
+
+		return new Material( shader ) { hideFlags = HideFlags.DontSave };
+	}
+
+	public static int SafeAllocateTemporaryRT( CommandBuffer cb, string propertyName,
+												int width, int height,
+												RenderTextureFormat format = RenderTextureFormat.Default,
+												RenderTextureReadWrite readWrite = RenderTextureReadWrite.Default,
+												FilterMode filterMode = FilterMode.Point )
+	{
+		int id = Shader.PropertyToID( propertyName );
+
+		cb.GetTemporaryRT( id, width, height, 0, filterMode, format, readWrite );
+
+		return id;
+	}
+
+
+	public static void SafeReleaseTemporaryRT( CommandBuffer cb, int id )
+	{
+		cb.ReleaseTemporaryRT( id );
+	}
+
+
+	public static RenderTexture SafeAllocateRT(	string name,
+												int width, int height,
+												RenderTextureFormat format,
+												RenderTextureReadWrite readWrite,
+												FilterMode filterMode = FilterMode.Point,
+												int antiAliasing = 1,
+												bool aUseMipMap = false )
+	{
+		width = Mathf.Clamp( width, 1, 65536 );
+		height = Mathf.Clamp( height, 1, 65536 );
+
+		RenderTexture rt = new RenderTexture( width, height, 0, format, readWrite ) { hideFlags = HideFlags.DontSave };
+
+		rt.name = name;
+		rt.filterMode = filterMode;
+		rt.wrapMode = TextureWrapMode.Clamp;
+		rt.antiAliasing = Mathf.Max( antiAliasing, 1 );
+		rt.useMipMap = aUseMipMap;
+		rt.Create();
+
+		return rt;
+	}
+
+
+	public static void SafeReleaseRT( ref RenderTexture rt )
+	{
+		if( rt != null )
+		{
+			RenderTexture.active = null;
+
+			rt.Release();
+			RenderTexture.DestroyImmediate( rt );
+
+			rt = null;
+		}
+	}
+
+
+	public static bool IsStereoSinglePassEnabled( Camera aCamera )
+	{
+	#if UNITY_EDITOR
+		return aCamera.stereoEnabled && ( PlayerSettings.stereoRenderingPath == StereoRenderingPath.SinglePass );
+	#else
+
+		#if UNITY_2017_2_OR_NEWER && !UNITY_SWITCH && !UNITY_XBOXONE && !UNITY_PS4
+			return	aCamera.stereoEnabled && ( UnityEngine.XR.XRSettings.eyeTextureDesc.vrUsage == VRTextureUsage.TwoEyes );
+		#else
+			return	false;
+		#endif
+
+	#endif
+	}
+
+	public static bool IsStereoMultiPassEnabled( Camera aCamera )
+	{
+	#if UNITY_EDITOR
+		return aCamera.stereoEnabled && ( PlayerSettings.stereoRenderingPath == StereoRenderingPath.MultiPass );
+	#else
+
+		#if UNITY_2017_2_OR_NEWER && !UNITY_SWITCH && !UNITY_XBOXONE && !UNITY_PS4
+			return	aCamera.stereoEnabled && ( UnityEngine.XR.XRSettings.eyeTextureDesc.vrUsage == VRTextureUsage.OneEye );
+		#else
+			return	false;
+		#endif
+
+	#endif
+	}
+
+	public static void UpdateGlobalShaderConstants( CommandBuffer cb, ref TargetDesc aTarget, Camera aCamera, bool isDownsample, bool isFilterDownsample )
+	{
+	#if UNITY_2017_2_OR_NEWER && !UNITY_SWITCH && !UNITY_XBOXONE && !UNITY_PS4
+		if( UnityEngine.XR.XRSettings.enabled == true )
+		{
+			aTarget.fullWidth = (int)( UnityEngine.XR.XRSettings.eyeTextureDesc.width * UnityEngine.XR.XRSettings.eyeTextureResolutionScale );
+			aTarget.fullHeight = (int)( UnityEngine.XR.XRSettings.eyeTextureDesc.height * UnityEngine.XR.XRSettings.eyeTextureResolutionScale );
+		}
+		else
+		{
+			aTarget.fullWidth = aCamera.pixelWidth;
+			aTarget.fullHeight = aCamera.pixelHeight;
+		}
+	#else
+		aTarget.fullWidth = aCamera.pixelWidth;
+		aTarget.fullHeight = aCamera.pixelHeight;
+	#endif
+
+		if( isFilterDownsample == true )
+		{
+			aTarget.width = aTarget.fullWidth / 2;
+			aTarget.height = aTarget.fullHeight / 2;
+		}
+		else
+		{
+			aTarget.width = aTarget.fullWidth;
+			aTarget.height = aTarget.fullHeight;
+		}
+
+		aTarget.oneOverWidth = 1.0f / (float)aTarget.width;
+		aTarget.oneOverHeight = 1.0f / (float)aTarget.height;
+
+		float fovRad = aCamera.fieldOfView * Mathf.Deg2Rad;
+
+		float invHalfTanFov = 1.0f / Mathf.Tan( fovRad * 0.5f );
+
+		Vector2 focalLen = new Vector2( invHalfTanFov * ( aTarget.height / (float)aTarget.width ),
+										invHalfTanFov );
+
+		Vector2 invFocalLen = new Vector2( 1.0f / focalLen.x, 1.0f / focalLen.y );
+
+		// Aspect Ratio
+		cb.SetGlobalVector( PropertyID._AO_UVToView, new Vector4( +2.0f * invFocalLen.x,
+																  +2.0f * invFocalLen.y,
+																  -1.0f * invFocalLen.x,
+																  -1.0f * invFocalLen.y ) );
+
+		float projScale;
+
+		if( aCamera.orthographic )
+			projScale = ( (float)aTarget.fullHeight ) / aCamera.orthographicSize;
+		else
+			projScale = ( (float)aTarget.fullHeight ) / ( Mathf.Tan( fovRad * 0.5f ) * 2.0f );
+
+		if( ( isDownsample == true ) || ( isFilterDownsample == true ) )
+		{
+			projScale = projScale * 0.5f * 0.5f;
+		}
+		else
+		{
+			projScale = projScale * 0.5f;
+		}
+
+		cb.SetGlobalFloat( PropertyID._AO_HalfProjScale, projScale );
+	}
+}
+
+
+public class AmplifyOcclusionViewProjMatrix
+{
+	private Matrix4x4 m_prevViewProjMatrixLeft = Matrix4x4.identity;
+	private Matrix4x4 m_prevInvViewProjMatrixLeft = Matrix4x4.identity;
+	private Matrix4x4 m_prevViewProjMatrixRight = Matrix4x4.identity;
+	private Matrix4x4 m_prevInvViewProjMatrixRight = Matrix4x4.identity;
+
+	public void UpdateGlobalShaderConstants_Matrices( CommandBuffer cb, Camera aCamera, bool isUsingTemporalFilter )
+	{
+		// Camera matrixes
+		if( AmplifyOcclusionCommon.IsStereoSinglePassEnabled( aCamera ) == true )
+		{
+			Matrix4x4 viewLeft = aCamera.GetStereoViewMatrix( Camera.StereoscopicEye.Left );
+			Matrix4x4 viewRight = aCamera.GetStereoViewMatrix( Camera.StereoscopicEye.Right );
+
+			cb.SetGlobalMatrix( PropertyID._AO_CameraViewLeft, viewLeft );
+			cb.SetGlobalMatrix( PropertyID._AO_CameraViewRight, viewRight );
+
+			Matrix4x4 projectionMatrixLeft = aCamera.GetStereoProjectionMatrix( Camera.StereoscopicEye.Left );
+			Matrix4x4 projectionMatrixRight = aCamera.GetStereoProjectionMatrix( Camera.StereoscopicEye.Right );
+
+			Matrix4x4 projLeft = GL.GetGPUProjectionMatrix( projectionMatrixLeft, false );
+			Matrix4x4 projRight = GL.GetGPUProjectionMatrix( projectionMatrixRight, false );
+
+			cb.SetGlobalMatrix( PropertyID._AO_ProjMatrixLeft, projLeft );
+			cb.SetGlobalMatrix( PropertyID._AO_ProjMatrixRight, projRight );
+
+			if( isUsingTemporalFilter )
+			{
+				Matrix4x4 ViewProjMatrixLeft = projLeft * viewLeft;
+				Matrix4x4 ViewProjMatrixRight = projRight * viewRight;
+
+				Matrix4x4 InvViewProjMatrixLeft = Matrix4x4.Inverse( ViewProjMatrixLeft );
+				Matrix4x4 InvViewProjMatrixRight = Matrix4x4.Inverse( ViewProjMatrixRight );
+
+				cb.SetGlobalMatrix( PropertyID._AO_InvViewProjMatrixLeft, InvViewProjMatrixLeft );
+				cb.SetGlobalMatrix( PropertyID._AO_PrevViewProjMatrixLeft, m_prevViewProjMatrixLeft );
+				cb.SetGlobalMatrix( PropertyID._AO_PrevInvViewProjMatrixLeft, m_prevInvViewProjMatrixLeft );
+
+				cb.SetGlobalMatrix( PropertyID._AO_InvViewProjMatrixRight, InvViewProjMatrixRight );
+				cb.SetGlobalMatrix( PropertyID._AO_PrevViewProjMatrixRight, m_prevViewProjMatrixRight );
+				cb.SetGlobalMatrix( PropertyID._AO_PrevInvViewProjMatrixRight, m_prevInvViewProjMatrixRight );
+
+				m_prevViewProjMatrixLeft = ViewProjMatrixLeft;
+				m_prevInvViewProjMatrixLeft = InvViewProjMatrixLeft;
+
+				m_prevViewProjMatrixRight = ViewProjMatrixRight;
+				m_prevInvViewProjMatrixRight = InvViewProjMatrixRight;
+			}
+		}
+		else
+		{
+			Matrix4x4 view = aCamera.worldToCameraMatrix;
+
+			cb.SetGlobalMatrix( PropertyID._AO_CameraViewLeft, view );
+
+			if( isUsingTemporalFilter )
+			{
+				Matrix4x4 proj = GL.GetGPUProjectionMatrix( aCamera.projectionMatrix, false );
+
+				Matrix4x4 ViewProjMatrix = proj * view;
+				Matrix4x4 InvViewProjMatrix = Matrix4x4.Inverse( ViewProjMatrix );
+
+				cb.SetGlobalMatrix( PropertyID._AO_InvViewProjMatrixLeft, InvViewProjMatrix );
+				cb.SetGlobalMatrix( PropertyID._AO_PrevViewProjMatrixLeft, m_prevViewProjMatrixLeft );
+				cb.SetGlobalMatrix( PropertyID._AO_PrevInvViewProjMatrixLeft, m_prevInvViewProjMatrixLeft );
+
+				m_prevViewProjMatrixLeft = ViewProjMatrix;
+				m_prevInvViewProjMatrixLeft = InvViewProjMatrix;
+			}
+		}
+	}
+
+}
+
+public enum SampleCountLevel
+{
+	Low = 0,
+	Medium,
+	High,
+	VeryHigh
+}
+
+public struct TargetDesc
+{
+	public int fullWidth;
+	public int fullHeight;
+	public int width;
+	public int height;
+	public float oneOverWidth;
+	public float oneOverHeight;
+}
+
+public static class ShaderPass
+{
+	public const int OcclusionLow_None_UseDynamicDepthMips = 16;
+	public const int CombineDownsampledOcclusionDepth = 32;
+	public const int NeighborMotionIntensity = 33;
+	public const int ClearTemporal = 34;
+	public const int ScaleDownCloserDepthEven = 35;
+	public const int ScaleDownCloserDepthEven_CameraDepthTexture = 36;
+	public const int Temporal = 37;
+
+	// Blur
+	public const int BlurHorizontal1 = 0;
+	public const int BlurVertical1 = 1;
+	public const int BlurHorizontal2 = 2;
+	public const int BlurVertical2 = 3;
+	public const int BlurHorizontal3 = 4;
+	public const int BlurVertical3 = 5;
+	public const int BlurHorizontal4 = 6;
+	public const int BlurVertical4 = 7;
+	public const int BlurHorizontalIntensity = 8;
+	public const int BlurVerticalIntensity = 9;
+
+	// Apply Occlusion
+	public const int ApplyDebug = 0;
+	public const int ApplyDebugTemporal = 1;
+	public const int ApplyDeferred = 3;
+	public const int ApplyDeferredTemporal = 4;
+	public const int ApplyDeferredLog = 6;
+	public const int ApplyDeferredLogTemporal = 7;
+	public const int ApplyPostEffect = 9;
+	public const int ApplyPostEffectTemporal = 10;
+	public const int ApplyPostEffectTemporalMultiply = 12;
+	public const int ApplyDeferredTemporalMultiply = 13;
+	public const int ApplyDebugCombineFromTemporal = 14;
+	public const int ApplyCombineFromTemporal = 15;
+	public const int ApplyDeferredCombineFromTemporal = 16;
+	public const int ApplyDeferredLogCombineFromTemporal = 17;
+
+	// Occlusion Normal Targets
+	public const int OcclusionLow_None = 0;
+	public const int OcclusionLow_Camera = 1;
+	public const int OcclusionLow_GBuffer = 2;
+	public const int OcclusionLow_GBufferOctaEncoded = 3;
+}
+
+public static class PropertyID
+{
+	public static readonly int _MainTex = Shader.PropertyToID( "_MainTex" );
+	public static readonly int _AO_Radius = Shader.PropertyToID( "_AO_Radius" );
+	public static readonly int _AO_PowExponent = Shader.PropertyToID( "_AO_PowExponent" );
+	public static readonly int _AO_Bias = Shader.PropertyToID( "_AO_Bias" );
+	public static readonly int _AO_Levels = Shader.PropertyToID( "_AO_Levels" );
+	public static readonly int _AO_ThicknessDecay = Shader.PropertyToID( "_AO_ThicknessDecay" );
+	public static readonly int _AO_BlurSharpness = Shader.PropertyToID( "_AO_BlurSharpness" );
+	public static readonly int _AO_BufDepthToLinearEye = Shader.PropertyToID( "_AO_BufDepthToLinearEye" );
+	public static readonly int _AO_CameraViewLeft = Shader.PropertyToID( "_AO_CameraViewLeft" );
+	public static readonly int _AO_CameraViewRight = Shader.PropertyToID( "_AO_CameraViewRight" );
+	public static readonly int _AO_ProjMatrixLeft = Shader.PropertyToID( "_AO_ProjMatrixLeft" );
+	public static readonly int _AO_ProjMatrixRight = Shader.PropertyToID( "_AO_ProjMatrixRight" );
+	public static readonly int _AO_InvViewProjMatrixLeft = Shader.PropertyToID( "_AO_InvViewProjMatrixLeft" );
+	public static readonly int _AO_PrevViewProjMatrixLeft = Shader.PropertyToID( "_AO_PrevViewProjMatrixLeft" );
+	public static readonly int _AO_PrevInvViewProjMatrixLeft = Shader.PropertyToID( "_AO_PrevInvViewProjMatrixLeft" );
+	public static readonly int _AO_InvViewProjMatrixRight = Shader.PropertyToID( "_AO_InvViewProjMatrixRight" );
+	public static readonly int _AO_PrevViewProjMatrixRight = Shader.PropertyToID( "_AO_PrevViewProjMatrixRight" );
+	public static readonly int _AO_PrevInvViewProjMatrixRight = Shader.PropertyToID( "_AO_PrevInvViewProjMatrixRight" );
+	public static readonly int _AO_GBufferNormals = Shader.PropertyToID( "_AO_GBufferNormals" );
+	public static readonly int _AO_Target_TexelSize = Shader.PropertyToID( "_AO_Target_TexelSize" );
+	public static readonly int _AO_TemporalCurveAdj = Shader.PropertyToID( "_AO_TemporalCurveAdj" );
+	public static readonly int _AO_TemporalMotionSensibility = Shader.PropertyToID( "_AO_TemporalMotionSensibility" );
+	public static readonly int _AO_CurrOcclusionDepth = Shader.PropertyToID( "_AO_CurrOcclusionDepth" );
+	public static readonly int _AO_CurrOcclusionDepth_TexelSize = Shader.PropertyToID( "_AO_CurrOcclusionDepth_TexelSize" );
+	public static readonly int _AO_TemporalAccumm = Shader.PropertyToID( "_AO_TemporalAccumm" );
+	public static readonly int _AO_TemporalDirections = Shader.PropertyToID( "_AO_TemporalDirections" );
+	public static readonly int _AO_TemporalOffsets = Shader.PropertyToID( "_AO_TemporalOffsets" );
+	public static readonly int _AO_GBufferAlbedo = Shader.PropertyToID( "_AO_GBufferAlbedo" );
+	public static readonly int _AO_GBufferEmission = Shader.PropertyToID( "_AO_GBufferEmission" );
+	public static readonly int _AO_UVToView = Shader.PropertyToID( "_AO_UVToView" );
+	public static readonly int _AO_HalfProjScale = Shader.PropertyToID( "_AO_HalfProjScale" );
+	public static readonly int _AO_FadeParams = Shader.PropertyToID( "_AO_FadeParams" );
+	public static readonly int _AO_FadeValues = Shader.PropertyToID( "_AO_FadeValues" );
+	public static readonly int _AO_FadeToTint = Shader.PropertyToID( "_AO_FadeToTint" );
+	public static readonly int _AO_CurrMotionIntensity = Shader.PropertyToID( "_AO_CurrMotionIntensity" );
+	public static readonly int _AO_CurrDepthSource_TexelSize = Shader.PropertyToID( "_AO_CurrDepthSource_TexelSize" );
+	public static readonly int _AO_CurrDepthSource = Shader.PropertyToID( "_AO_CurrDepthSource" );
+	public static readonly int _AO_CurrMotionIntensity_TexelSize = Shader.PropertyToID( "_AO_CurrMotionIntensity_TexelSize" );
+	public static readonly int _AO_SourceDepthMipmap = Shader.PropertyToID( "_AO_SourceDepthMipmap" );
+	public static readonly int _AO_Source_TexelSize = Shader.PropertyToID( "_AO_Source_TexelSize" );
+}
+
+}

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Plugins/AmplifyOcclusionCommon.cs.meta
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Plugins/AmplifyOcclusionCommon.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7ab719fca8c732f4ba57ab60bd756194
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Plugins/AmplifyOcclusionEffect.cs
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Plugins/AmplifyOcclusionEffect.cs
@@ -1,0 +1,1411 @@
+// Amplify Occlusion 2 - Robust Ambient Occlusion for Unity
+// Copyright (c) Amplify Creations, Lda <info@amplify.pt>
+
+using System;
+using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.Profiling;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+using AmplifyOcclusion;
+
+[ExecuteInEditMode]
+[AddComponentMenu( "Image Effects/Amplify Occlusion" )]
+[ImageEffectAllowedInSceneView]
+[RequireComponent( typeof( Camera ) )]
+public class AmplifyOcclusionEffect : MonoBehaviour
+{
+	private static int m_nextID = 0;
+	private int m_myID;
+	private string m_myIDstring;
+
+	private float m_oneOverDepthScale = ( 1.0f / 65504.0f ); // 65504.0f max half float
+
+	public enum ApplicationMethod
+	{
+		PostEffect = 0,
+		Deferred,
+		Debug
+	}
+
+	public enum PerPixelNormalSource
+	{
+		None = 0,
+		Camera,
+		GBuffer,
+		GBufferOctaEncoded,
+	}
+
+	[Header( "Ambient Occlusion" )]
+	[Tooltip( "How to inject the occlusion: Post Effect = Overlay, Deferred = Deferred Injection, Debug - Vizualize." )]
+	public ApplicationMethod ApplyMethod = ApplicationMethod.PostEffect;
+
+	[Tooltip( "Number of samples per pass." )]
+	public SampleCountLevel SampleCount = SampleCountLevel.Medium;
+
+	[Tooltip( "Source of per-pixel normals: None = All, Camera = Forward, GBuffer = Deferred." )]
+	public PerPixelNormalSource PerPixelNormals = PerPixelNormalSource.Camera;
+
+	[Tooltip( "Final applied intensity of the occlusion effect." )]
+	[Range( 0, 1 )]
+	public float Intensity = 1.0f;
+
+	[Tooltip( "Color tint for occlusion." )]
+	public Color Tint = Color.black;
+
+	[Tooltip( "Radius spread of the occlusion." )]
+	public float Radius = 2.0f;
+
+	[Tooltip( "Power exponent attenuation of the occlusion." )]
+	[Range( 0, 16 )]
+	public float PowerExponent = 1.8f;
+
+	[Tooltip( "Controls the initial occlusion contribution offset." )]
+	[Range( 0, 0.99f )]
+	public float Bias = 0.05f;
+
+	[Tooltip( "Controls the thickness occlusion contribution." )]
+	[Range( 0, 1.0f )]
+	public float Thickness = 1.0f;
+
+	[Tooltip( "Compute the Occlusion and Blur at half of the resolution." )]
+	public bool Downsample = true;
+
+	[Tooltip( "Cache optimization for best performance / quality tradeoff." )]
+	public bool CacheAware = true;
+
+	[Header( "Distance Fade" )]
+	[Tooltip( "Control parameters at faraway." )]
+	public bool FadeEnabled = false;
+
+	[Tooltip( "Distance in Unity unities that start to fade." )]
+	public float FadeStart = 100.0f;
+
+	[Tooltip( "Length distance to performe the transition." )]
+	public float FadeLength = 50.0f;
+
+	[Tooltip( "Final Intensity parameter." )]
+	[Range( 0, 1 )]
+	public float FadeToIntensity = 0.0f;
+	public Color FadeToTint = Color.black;
+
+	[Tooltip( "Final Radius parameter." )]
+	public float FadeToRadius = 2.0f;
+
+	[Tooltip( "Final PowerExponent parameter." )]
+	[Range( 0, 16 )]
+	public float FadeToPowerExponent = 1.0f;
+
+	[Tooltip( "Final Thickness parameter." )]
+	[Range( 0, 1.0f )]
+	public float FadeToThickness = 1.0f;
+
+	[Header( "Bilateral Blur" )]
+	public bool BlurEnabled = true;
+
+	[Tooltip( "Radius in screen pixels." )]
+	[Range( 1, 4 )]
+	public int BlurRadius = 3;
+
+	[Tooltip( "Number of times that the Blur will repeat." )]
+	[Range( 1, 4 )]
+	public int BlurPasses = 1;
+
+	[Tooltip( "Sharpness of blur edge-detection: 0 = Softer Edges, 20 = Sharper Edges." )]
+	[Range( 0, 20 )]
+	public float BlurSharpness = 15.0f;
+
+	[Header( "Temporal Filter" )]
+	[Tooltip( "Accumulates the effect over the time." )]
+	public bool FilterEnabled = true;
+	public bool FilterDownsample = true;
+
+	[Tooltip( "Controls the accumulation decayment: 0 = More flicker with less ghosting, 1 = Less flicker with more ghosting." )]
+	[Range( 0, 1 )]
+	public float FilterBlending = 0.80f;
+
+	[Tooltip( "Controls the discard sensitivity based on the motion of the scene and objects." )]
+	[Range( 0, 1 )]
+	public float FilterResponse = 0.50f;
+
+	// Current state variables
+	private bool m_HDR = true;
+	private bool m_MSAA = true;
+
+	// Previous state variables
+	private PerPixelNormalSource m_prevPerPixelNormals;
+	private ApplicationMethod m_prevApplyMethod;
+	private bool m_prevDeferredReflections = false;
+	private SampleCountLevel m_prevSampleCount = SampleCountLevel.Low;
+	private bool m_prevDownsample = false;
+	private bool m_prevCacheAware = false;
+	private bool m_prevBlurEnabled = false;
+	private int m_prevBlurRadius = 0;
+	private int m_prevBlurPasses = 0;
+	private bool m_prevFilterEnabled = true;
+	private bool m_prevFilterDownsample = true;
+	private bool m_prevHDR = true;
+	private bool m_prevMSAA = true;
+
+#if UNITY_EDITOR
+	private bool m_prevIsPlaying = false;
+#endif
+
+	private Camera m_targetCamera = null;
+
+	private RenderTargetIdentifier[] applyDebugTargetsTemporal = new RenderTargetIdentifier[2];
+	private RenderTargetIdentifier[] applyDeferredTargets_Log_Temporal = new RenderTargetIdentifier[3];
+	private RenderTargetIdentifier[] applyDeferredTargetsTemporal = new RenderTargetIdentifier[3];
+	private RenderTargetIdentifier[] applyOcclusionTemporal = new RenderTargetIdentifier[2];
+	private RenderTargetIdentifier[] applyPostEffectTargetsTemporal = new RenderTargetIdentifier[2];
+
+	// NOTE: MotionVectors are not supported in Deferred Injection mode due to 1 frame delay
+	private bool UsingTemporalFilter { get { return ( m_sampleStep > 0 ) && ( FilterEnabled == true ) && ( m_targetCamera.cameraType != UnityEngine.CameraType.SceneView ); } }
+	private bool UsingMotionVectors { get { return UsingTemporalFilter && ( ApplyMethod != ApplicationMethod.Deferred ); } }
+	private bool UsingFilterDownsample { get { return ( Downsample == true ) && ( FilterDownsample == true ) && ( UsingTemporalFilter == true ); } }
+
+	private bool useMRTBlendingFallback = false;
+	private bool checkedforMRTBlendingFallback = false;
+
+	// Command buffer
+	private struct CmdBuffer
+	{
+		public CommandBuffer cmdBuffer;
+		public CameraEvent cmdBufferEvent;
+		public string cmdBufferName;
+	}
+
+	CmdBuffer m_commandBuffer_Parameters;
+	CmdBuffer m_commandBuffer_Occlusion;
+	CmdBuffer m_commandBuffer_Apply;
+
+	private void createCommandBuffer( ref CmdBuffer aCmdBuffer, string aCmdBufferName, CameraEvent aCameraEvent )
+	{
+		if( aCmdBuffer.cmdBuffer != null )
+		{
+			cleanupCommandBuffer( ref aCmdBuffer );
+		}
+
+		aCmdBuffer.cmdBufferName = aCmdBufferName;
+
+		aCmdBuffer.cmdBuffer = new CommandBuffer();
+		aCmdBuffer.cmdBuffer.name = aCmdBufferName;
+
+		aCmdBuffer.cmdBufferEvent = aCameraEvent;
+
+		m_targetCamera.AddCommandBuffer( aCameraEvent, aCmdBuffer.cmdBuffer );
+	}
+
+	private void cleanupCommandBuffer( ref CmdBuffer aCmdBuffer )
+	{
+		CommandBuffer[] currentCBs = m_targetCamera.GetCommandBuffers( aCmdBuffer.cmdBufferEvent );
+
+		for( int i = 0; i < currentCBs.Length; i++ )
+		{
+			if( currentCBs[ i ].name == aCmdBuffer.cmdBufferName )
+			{
+				m_targetCamera.RemoveCommandBuffer( aCmdBuffer.cmdBufferEvent, currentCBs[ i ] );
+			}
+		}
+
+		aCmdBuffer.cmdBufferName = null;
+		aCmdBuffer.cmdBufferEvent = 0;
+		aCmdBuffer.cmdBuffer = null;
+	}
+
+	// Quad Mesh
+	static private Mesh m_quadMesh = null;
+
+	private void createQuadMesh()
+	{
+		if( m_quadMesh == null )
+		{
+			m_quadMesh = new Mesh();
+			m_quadMesh.vertices = new Vector3[ 4 ] { new Vector3( 0, 0, 0 ), new Vector3( 0, 1, 0 ), new Vector3( 1, 1, 0 ), new Vector3( 1, 0, 0 ) };
+			m_quadMesh.uv = new Vector2[ 4 ] { new Vector2( 0, 0 ), new Vector2( 0, 1 ), new Vector2( 1, 1 ), new Vector2( 1, 0 ) };
+			m_quadMesh.triangles = new int[ 6 ] { 0, 1, 2, 0, 2, 3 };
+
+			m_quadMesh.normals = new Vector3[ 0 ];
+			m_quadMesh.tangents = new Vector4[ 0 ];
+			m_quadMesh.colors32 = new Color32[ 0 ];
+			m_quadMesh.colors = new Color[ 0 ];
+		}
+	}
+
+
+	void PerformBlit( CommandBuffer cb, Material mat, int pass )
+	{
+		cb.DrawMesh( m_quadMesh, Matrix4x4.identity, mat, 0, pass );
+	}
+
+	// Render Materials
+	static private Material m_occlusionMat = null;
+	static private Material m_blurMat = null;
+	static private Material m_applyOcclusionMat = null;
+
+	private void checkMaterials( bool aThroughErrorMsg )
+	{
+		if( m_occlusionMat == null )
+		{
+			m_occlusionMat = AmplifyOcclusionCommon.CreateMaterialWithShaderName( "Hidden/Amplify Occlusion/Occlusion", aThroughErrorMsg );
+		}
+
+		if( m_blurMat == null )
+		{
+			m_blurMat = AmplifyOcclusionCommon.CreateMaterialWithShaderName( "Hidden/Amplify Occlusion/Blur", aThroughErrorMsg );
+		}
+
+		if( m_applyOcclusionMat == null )
+		{
+			m_applyOcclusionMat = AmplifyOcclusionCommon.CreateMaterialWithShaderName( "Hidden/Amplify Occlusion/Apply", aThroughErrorMsg );
+		}
+
+		if( m_applyOcclusionMat != null )
+		{
+			if( checkedforMRTBlendingFallback == false )
+			{
+				checkedforMRTBlendingFallback = true;
+
+				// some platforms still don't support MRT-blending; provide a fallback, if necessary
+				useMRTBlendingFallback = m_applyOcclusionMat.GetTag( "MRTBlending", false ).ToUpper() != "TRUE";
+			}
+		}
+	}
+
+	private RenderTextureFormat m_occlusionRTFormat = RenderTextureFormat.RGHalf;
+	private RenderTextureFormat m_accumTemporalRTFormat = RenderTextureFormat.ARGB32;
+	private RenderTextureFormat m_temporaryEmissionRTFormat = RenderTextureFormat.ARGB2101010;
+	private RenderTextureFormat m_motionIntensityRTFormat = RenderTextureFormat.R8;
+
+
+	private bool checkRenderTextureFormats()
+	{
+		// test the two fallback formats first
+		if( SystemInfo.SupportsRenderTextureFormat( RenderTextureFormat.ARGB32 ) && SystemInfo.SupportsRenderTextureFormat( RenderTextureFormat.ARGBHalf ) )
+		{
+			m_occlusionRTFormat = RenderTextureFormat.RGHalf;
+			if( !SystemInfo.SupportsRenderTextureFormat( m_occlusionRTFormat ) )
+			{
+				m_occlusionRTFormat = RenderTextureFormat.RGFloat;
+				if( !SystemInfo.SupportsRenderTextureFormat( m_occlusionRTFormat ) )
+				{
+					// already tested above
+					m_occlusionRTFormat = RenderTextureFormat.ARGBHalf;
+				}
+			}
+
+			return true;
+		}
+		return false;
+	}
+
+
+	void OnEnable()
+	{
+		m_myID = m_nextID;
+		m_myIDstring = m_myID.ToString();
+		m_nextID++;
+
+		if( !checkRenderTextureFormats() )
+		{
+			Debug.LogError( "[AmplifyOcclusion] Target platform does not meet the minimum requirements for this effect to work properly." );
+
+			this.enabled = false;
+
+			return;
+		}
+
+		if( CacheAware == true )
+		{
+			if( SystemInfo.SupportsRenderTextureFormat( RenderTextureFormat.RFloat ) == false )
+			{
+				CacheAware = false;
+				UnityEngine.Debug.LogWarning( "[AmplifyOcclusion] System does not support RFloat RenderTextureFormat. CacheAware will be disabled." );
+			}
+			else
+			{
+				if( SystemInfo.copyTextureSupport == CopyTextureSupport.None )
+				{
+					CacheAware = false;
+					UnityEngine.Debug.LogWarning( "[AmplifyOcclusion] System does not support CopyTexture. CacheAware will be disabled." );
+				}
+				else
+				{
+					// AO-62 - some OpenGLES devices actually implement RFloat buffers using RHalf format.
+					if( ( SystemInfo.graphicsDeviceType == GraphicsDeviceType.OpenGLES2 ) ||
+						( SystemInfo.graphicsDeviceType == GraphicsDeviceType.OpenGLES3 ) )
+					{
+						CacheAware = false;
+						UnityEngine.Debug.LogWarningFormat( "[AmplifyOcclusion] CacheAware is not supported on {0} devices. CacheAware will be disabled.", SystemInfo.graphicsDeviceType );
+					}
+				}
+			}
+		}
+
+		checkMaterials( false );
+		createQuadMesh();
+
+		#if UNITY_2017_1_OR_NEWER
+			if( GraphicsSettings.HasShaderDefine( Graphics.activeTier, BuiltinShaderDefine.SHADER_API_MOBILE ) )
+			{
+				// using 16376.0 for DepthScale for mobile due to precision issues
+				m_oneOverDepthScale = 1.0f / 16376.0f;
+			}
+		#else
+		#if UNITY_IPHONE || UNITY_ANDROID
+			m_oneOverDepthScale = 1.0f / 16376.0f;
+		#endif
+		#endif
+	}
+
+
+	void Reset()
+	{
+		if( m_commandBuffer_Parameters.cmdBuffer != null )
+		{
+			cleanupCommandBuffer( ref m_commandBuffer_Parameters );
+		}
+
+		if( m_commandBuffer_Occlusion.cmdBuffer != null )
+		{
+			cleanupCommandBuffer( ref m_commandBuffer_Occlusion );
+		}
+
+		if( m_commandBuffer_Apply.cmdBuffer != null )
+		{
+			cleanupCommandBuffer( ref m_commandBuffer_Apply );
+		}
+
+		AmplifyOcclusionCommon.SafeReleaseRT( ref m_occlusionDepthRT );
+		AmplifyOcclusionCommon.SafeReleaseRT( ref m_depthMipmap );
+		releaseTemporalRT();
+
+		m_tmpMipString = null;
+	}
+
+	void OnDisable()
+	{
+		Reset();
+	}
+
+	private void releaseTemporalRT()
+	{
+		if( m_temporalAccumRT != null )
+		{
+			for( int i = 0; i < m_temporalAccumRT.Length; i++ )
+			{
+				AmplifyOcclusionCommon.SafeReleaseRT( ref m_temporalAccumRT[ i ] );
+			}
+		}
+
+		m_temporalAccumRT = null;
+	}
+
+	private bool m_paramsChanged = true;
+	private bool m_clearHistory = true;
+
+	private void ClearHistory( CommandBuffer cb )
+	{
+		m_clearHistory = false;
+
+		if ( ( m_temporalAccumRT != null ) && ( m_occlusionDepthRT != null ) )
+		{
+			for( int i = 0; i < m_temporalAccumRT.Length; i++ )
+			{
+				cb.SetRenderTarget( m_temporalAccumRT[ i ] );
+				PerformBlit( cb, m_occlusionMat, ShaderPass.ClearTemporal );
+			}
+		}
+	}
+
+	private void checkParamsChanged()
+	{
+		bool HDR = m_targetCamera.allowHDR; // && tier?
+		bool MSAA = m_targetCamera.allowMSAA &&
+					m_targetCamera.actualRenderingPath != RenderingPath.DeferredLighting &&
+					m_targetCamera.actualRenderingPath != RenderingPath.DeferredShading &&
+					QualitySettings.antiAliasing >= 1;
+
+		int antiAliasing = MSAA ? QualitySettings.antiAliasing : 1;
+
+		if( m_occlusionDepthRT != null )
+		{
+			if( ( m_occlusionDepthRT.width != m_target.width ) ||
+				( m_occlusionDepthRT.height != m_target.height ) ||
+				( m_prevMSAA != MSAA ) ||
+				( !m_occlusionDepthRT.IsCreated() ) ||
+				( m_prevFilterEnabled != FilterEnabled ) ||
+				( m_prevFilterDownsample != UsingFilterDownsample ) ||
+				( m_temporalAccumRT != null && ( !m_temporalAccumRT[ 0 ].IsCreated() || !m_temporalAccumRT[ 1 ].IsCreated() ) )
+#if UNITY_EDITOR
+				|| ( ( m_prevIsPlaying == true ) && ( EditorApplication.isPlaying == false ) )
+#endif
+				)
+			{
+				AmplifyOcclusionCommon.SafeReleaseRT( ref m_occlusionDepthRT );
+				AmplifyOcclusionCommon.SafeReleaseRT( ref m_depthMipmap );
+				releaseTemporalRT();
+
+				m_paramsChanged = true;
+			}
+		}
+
+		if( m_temporalAccumRT != null )
+		{
+			if( AmplifyOcclusionCommon.IsStereoMultiPassEnabled( m_targetCamera ) == true )
+			{
+				if( m_temporalAccumRT.Length != 4 )
+				{
+					m_temporalAccumRT = null;
+				}
+			}
+			else
+			{
+				if( m_temporalAccumRT.Length != 2 )
+				{
+					m_temporalAccumRT = null;
+				}
+			}
+		}
+
+		if( m_occlusionDepthRT == null )
+		{
+			m_occlusionDepthRT = AmplifyOcclusionCommon.SafeAllocateRT( "_AO_OcclusionDepthTexture",
+																		m_target.width,
+																		m_target.height,
+																		m_occlusionRTFormat,
+																		RenderTextureReadWrite.Linear,
+																		FilterMode.Bilinear );
+		}
+
+		if( m_temporalAccumRT == null && FilterEnabled )
+		{
+			if( AmplifyOcclusionCommon.IsStereoMultiPassEnabled( m_targetCamera ) == true )
+			{
+				m_temporalAccumRT = new RenderTexture[ 4 ];
+			}
+			else
+			{
+				m_temporalAccumRT = new RenderTexture[ 2 ];
+			}
+
+			for( int i = 0; i < m_temporalAccumRT.Length; i++ )
+			{
+				m_temporalAccumRT[ i ] = AmplifyOcclusionCommon.SafeAllocateRT( "_AO_TemporalAccum_" + i.ToString(),
+																				m_target.width,
+																				m_target.height,
+																				m_accumTemporalRTFormat,
+																				RenderTextureReadWrite.Linear,
+																				FilterMode.Bilinear,
+																				antiAliasing );
+			}
+
+			m_clearHistory = true;
+		}
+
+		if( ( CacheAware == true ) && ( m_depthMipmap == null ) )
+		{
+			m_depthMipmap = AmplifyOcclusionCommon.SafeAllocateRT( "_AO_DepthMipmap",
+																	m_target.fullWidth >> 1,
+																	m_target.fullHeight >> 1,
+																	RenderTextureFormat.RFloat,
+																	RenderTextureReadWrite.Linear,
+																	FilterMode.Point,
+																	1,
+																	true );
+
+			int minSize = (int)Mathf.Min( m_target.fullWidth, m_target.fullHeight );
+			m_numberMips = (int)( Mathf.Log( (float)minSize, 2.0f ) + 1.0f ) - 1;
+
+			m_tmpMipString = null;
+			m_tmpMipString = new string[m_numberMips];
+
+			for( int i = 0; i < m_numberMips; i++ )
+			{
+				m_tmpMipString[i] = "_AO_TmpMip_" + i.ToString();
+			}
+		}
+		else
+		{
+			if( ( CacheAware == false ) && ( m_depthMipmap != null ) )
+			{
+				AmplifyOcclusionCommon.SafeReleaseRT( ref m_depthMipmap );
+				m_tmpMipString = null;
+			}
+		}
+
+		if( ( m_prevSampleCount != SampleCount ) ||
+			( m_prevDownsample != Downsample ) ||
+			( m_prevCacheAware != CacheAware ) ||
+			( m_prevBlurEnabled != BlurEnabled ) ||
+			( ( ( m_prevBlurPasses != BlurPasses ) ||
+			    ( m_prevBlurRadius != BlurRadius ) ) && ( BlurEnabled == true ) ) ||
+			( m_prevFilterEnabled != FilterEnabled ) ||
+			( m_prevFilterDownsample != UsingFilterDownsample ) ||
+			( m_prevHDR != HDR ) ||
+			( m_prevMSAA != MSAA ) )
+		{
+			m_clearHistory |= ( m_prevHDR != HDR );
+			m_clearHistory |= ( m_prevMSAA != MSAA );
+
+			m_HDR = HDR;
+			m_MSAA = MSAA;
+
+			m_paramsChanged = true;
+		}
+
+#if UNITY_EDITOR
+		m_prevIsPlaying = EditorApplication.isPlaying;
+#endif
+	}
+
+
+	private void updateParams()
+	{
+		m_prevSampleCount = SampleCount;
+		m_prevDownsample = Downsample;
+		m_prevCacheAware = CacheAware;
+		m_prevBlurEnabled = BlurEnabled;
+		m_prevBlurPasses = BlurPasses;
+		m_prevBlurRadius = BlurRadius;
+		m_prevFilterEnabled = FilterEnabled;
+		m_prevFilterDownsample = UsingFilterDownsample;
+		m_prevHDR = m_HDR;
+		m_prevMSAA = m_MSAA;
+
+		m_paramsChanged = false;
+	}
+
+	void Update()
+	{
+		if( m_targetCamera != null )
+		{
+			if( m_targetCamera.actualRenderingPath != RenderingPath.DeferredShading )
+			{
+				if( PerPixelNormals != PerPixelNormalSource.None && PerPixelNormals != PerPixelNormalSource.Camera )
+				{
+					m_paramsChanged = true;
+					PerPixelNormals = PerPixelNormalSource.Camera;
+
+					if( m_targetCamera.cameraType != UnityEngine.CameraType.SceneView )
+					{
+						UnityEngine.Debug.LogWarning( "[AmplifyOcclusion] GBuffer Normals only available in Camera Deferred Shading mode. Switched to Camera source." );
+					}
+				}
+
+				if( ApplyMethod == ApplicationMethod.Deferred )
+				{
+					m_paramsChanged = true;
+					ApplyMethod = ApplicationMethod.PostEffect;
+
+					if( m_targetCamera.cameraType != UnityEngine.CameraType.SceneView )
+					{
+						UnityEngine.Debug.LogWarning( "[AmplifyOcclusion] Deferred Method requires a Deferred Shading path. Switching to Post Effect Method." );
+					}
+				}
+			}
+			else
+			{
+				if( PerPixelNormals == PerPixelNormalSource.Camera )
+				{
+					m_paramsChanged = true;
+					PerPixelNormals = PerPixelNormalSource.GBuffer;
+
+					if( m_targetCamera.cameraType != UnityEngine.CameraType.SceneView )
+					{
+						UnityEngine.Debug.LogWarning( "[AmplifyOcclusion] Camera Normals not supported for Deferred Method. Switching to GBuffer Normals." );
+					}
+				}
+			}
+
+			if( ( m_targetCamera.depthTextureMode & DepthTextureMode.Depth ) == 0 )
+			{
+				m_targetCamera.depthTextureMode |= DepthTextureMode.Depth;
+			}
+
+			if( ( PerPixelNormals == PerPixelNormalSource.Camera ) &&
+					( m_targetCamera.depthTextureMode & DepthTextureMode.DepthNormals ) == 0 )
+			{
+				m_targetCamera.depthTextureMode |= DepthTextureMode.DepthNormals;
+			}
+
+			if( ( UsingMotionVectors == true ) &&
+				( m_targetCamera.depthTextureMode & DepthTextureMode.MotionVectors ) == 0 )
+			{
+				m_targetCamera.depthTextureMode |= DepthTextureMode.MotionVectors;
+			}
+
+		}
+		else
+		{
+			m_targetCamera = GetComponent<Camera>();
+		}
+	}
+
+
+	void OnPreRender()
+	{
+		Profiler.BeginSample( "AO - OnPreRender" );
+
+		checkMaterials( true );
+
+		if( m_targetCamera != null )
+		{
+			#if UNITY_EDITOR
+			if( ( m_targetCamera.cameraType == UnityEngine.CameraType.SceneView ) &&
+				( ( ( PerPixelNormals == PerPixelNormalSource.GBuffer ) && ( m_targetCamera.orthographic == true ) ) ||
+				  ( PerPixelNormals == PerPixelNormalSource.Camera ) && 
+					
+					#if UNITY_2019_1_OR_NEWER
+					( SceneView.lastActiveSceneView.sceneLighting == false )
+					#else
+					( SceneView.lastActiveSceneView.m_SceneLighting == false )
+					#endif
+
+					) )
+			{
+				PerPixelNormals = PerPixelNormalSource.None;
+			}
+			#endif
+
+			bool deferredReflections = ( GraphicsSettings.GetShaderMode( BuiltinShaderType.DeferredReflections ) != BuiltinShaderMode.Disabled );
+
+			if( ( m_prevPerPixelNormals != PerPixelNormals ) ||
+				( m_prevApplyMethod != ApplyMethod ) ||
+				( m_prevDeferredReflections != deferredReflections ) ||
+				( m_commandBuffer_Parameters.cmdBuffer == null ) ||
+				( m_commandBuffer_Occlusion.cmdBuffer == null ) ||
+				( m_commandBuffer_Apply.cmdBuffer == null )
+				)
+			{
+				CameraEvent cameraStage = CameraEvent.BeforeImageEffectsOpaque;
+				if( ApplyMethod == ApplicationMethod.Deferred )
+				{
+					cameraStage = deferredReflections ? CameraEvent.BeforeReflections : CameraEvent.BeforeLighting;
+				}
+
+				createCommandBuffer( ref m_commandBuffer_Parameters, "AmplifyOcclusion_Parameters_" + m_myIDstring, cameraStage );
+				createCommandBuffer( ref m_commandBuffer_Occlusion, "AmplifyOcclusion_Compute_" + m_myIDstring, cameraStage );
+				createCommandBuffer( ref m_commandBuffer_Apply, "AmplifyOcclusion_Apply_" + m_myIDstring, cameraStage );
+
+				m_prevPerPixelNormals = PerPixelNormals;
+				m_prevApplyMethod = ApplyMethod;
+				m_prevDeferredReflections = deferredReflections;
+
+				m_paramsChanged = true;
+			}
+
+			if( ( m_commandBuffer_Parameters.cmdBuffer != null ) &&
+				( m_commandBuffer_Occlusion.cmdBuffer != null ) &&
+				( m_commandBuffer_Apply.cmdBuffer != null ) )
+			{
+				if( AmplifyOcclusionCommon.IsStereoMultiPassEnabled( m_targetCamera ) == true )
+				{
+					uint curStepIdx = ( m_sampleStep >> 1 ) & 1;
+					uint curEyeIdx = ( m_sampleStep & 1 );
+					m_curTemporalIdx  = ( curEyeIdx * 2 ) + ( 0 + curStepIdx );
+					m_prevTemporalIdx = ( curEyeIdx * 2 ) + ( 1 - curStepIdx );
+				}
+				else
+				{
+					uint curStepIdx = m_sampleStep & 1;
+					m_curTemporalIdx  = 0 + curStepIdx;
+					m_prevTemporalIdx = 1 - curStepIdx;
+				}
+
+				m_commandBuffer_Parameters.cmdBuffer.Clear();
+
+				UpdateGlobalShaderConstants( m_commandBuffer_Parameters.cmdBuffer );
+
+				UpdateGlobalShaderConstants_Matrices( m_commandBuffer_Parameters.cmdBuffer );
+
+				UpdateGlobalShaderConstants_AmbientOcclusion( m_commandBuffer_Parameters.cmdBuffer );
+
+				checkParamsChanged();
+
+				if( m_paramsChanged )
+				{
+					m_commandBuffer_Occlusion.cmdBuffer.Clear();
+
+					commandBuffer_FillComputeOcclusion( m_commandBuffer_Occlusion.cmdBuffer );
+				}
+
+				m_commandBuffer_Apply.cmdBuffer.Clear();
+
+				if( ApplyMethod == ApplicationMethod.Debug )
+				{
+					commandBuffer_FillApplyDebug( m_commandBuffer_Apply.cmdBuffer );
+				}
+				else
+				{
+					if( ApplyMethod == ApplicationMethod.PostEffect )
+					{
+						commandBuffer_FillApplyPostEffect( m_commandBuffer_Apply.cmdBuffer );
+					}
+					else
+					{
+						bool logTarget = !m_HDR;
+
+						commandBuffer_FillApplyDeferred( m_commandBuffer_Apply.cmdBuffer, logTarget );
+					}
+				}
+
+				updateParams();
+
+				m_sampleStep++; // No clamp, free running counter
+			}
+		}
+		else
+		{
+			m_targetCamera = GetComponent<Camera>();
+
+			Update();
+
+			#if UNITY_EDITOR
+			if( m_targetCamera.cameraType != UnityEngine.CameraType.SceneView )
+			{
+				System.Type T = System.Type.GetType( "UnityEditor.GameView,UnityEditor" );
+				UnityEngine.Object[] array = Resources.FindObjectsOfTypeAll( T );
+
+				if( array.Length > 0 )
+				{
+					EditorWindow gameView = (EditorWindow)array[ 0 ];
+					gameView.Focus();
+				}
+			}
+			#endif
+		}
+
+		Profiler.EndSample();
+	}
+
+
+	void OnPostRender()
+	{
+		if( m_occlusionDepthRT != null )
+		{
+			m_occlusionDepthRT.MarkRestoreExpected();
+		}
+		if( m_temporalAccumRT != null )
+		{
+			foreach ( var rt in m_temporalAccumRT )
+			{
+				rt.MarkRestoreExpected();
+			}
+		}
+	}
+
+
+	private RenderTexture m_occlusionDepthRT = null;
+	private RenderTexture[] m_temporalAccumRT = null;
+	private RenderTexture m_depthMipmap = null;
+
+	private uint m_sampleStep = 0;
+	private uint m_curTemporalIdx = 0;
+	private uint m_prevTemporalIdx = 0;
+
+	private string[] m_tmpMipString = null;
+	private int m_numberMips = 0;
+	private void commandBuffer_FillComputeOcclusion( CommandBuffer cb )
+	{
+		cb.BeginSample( "AO 1 - ComputeOcclusion" );
+
+		if( ( PerPixelNormals == PerPixelNormalSource.GBuffer ) ||
+			( PerPixelNormals == PerPixelNormalSource.GBufferOctaEncoded ) )
+		{
+			cb.SetGlobalTexture( PropertyID._AO_GBufferNormals, BuiltinRenderTextureType.GBuffer2 );
+		}
+
+		Vector4 oneOverFullSize_Size = new Vector4( 1.0f / (float)m_target.fullWidth,
+													1.0f / (float)m_target.fullHeight,
+													m_target.fullWidth,
+													m_target.fullHeight );
+
+		int sampleCountPass = ( (int)SampleCount ) * AmplifyOcclusionCommon.PerPixelNormalSourceCount;
+
+		int occlusionPass = ( ShaderPass.OcclusionLow_None +
+								sampleCountPass +
+								( (int)PerPixelNormals ) );
+
+		if( CacheAware == true )
+		{
+			occlusionPass += ShaderPass.OcclusionLow_None_UseDynamicDepthMips;
+
+			// Construct Depth mipmaps
+			int previouslyTmpMipRT = 0;
+
+			for( int i = 0; i < m_numberMips; i++ )
+			{
+				int tmpMipRT;
+
+				int width = m_target.fullWidth >> ( i + 1 );
+				int height = m_target.fullHeight >> ( i + 1 );
+
+				tmpMipRT = AmplifyOcclusionCommon.SafeAllocateTemporaryRT( cb, m_tmpMipString[ i ],
+																			width, height,
+																			RenderTextureFormat.RFloat,
+																			RenderTextureReadWrite.Linear,
+																			FilterMode.Bilinear );
+
+				// _AO_CurrDepthSource was previously set
+				cb.SetRenderTarget( tmpMipRT );
+
+				PerformBlit( cb, m_occlusionMat, ( ( i == 0 )?ShaderPass.ScaleDownCloserDepthEven_CameraDepthTexture:ShaderPass.ScaleDownCloserDepthEven ) );
+
+				cb.CopyTexture( tmpMipRT, 0, 0, m_depthMipmap, 0, i );
+
+				if( previouslyTmpMipRT != 0 )
+				{
+					AmplifyOcclusionCommon.SafeReleaseTemporaryRT( cb, previouslyTmpMipRT );
+				}
+
+				previouslyTmpMipRT = tmpMipRT;
+
+				cb.SetGlobalTexture( PropertyID._AO_CurrDepthSource, tmpMipRT ); // Set next MipRT ID
+			}
+
+			AmplifyOcclusionCommon.SafeReleaseTemporaryRT( cb, previouslyTmpMipRT );
+
+			cb.SetGlobalTexture( PropertyID._AO_SourceDepthMipmap, m_depthMipmap );
+		}
+
+		if( ( Downsample == true ) && ( UsingFilterDownsample == false ) )
+		{
+			int halfWidth = m_target.fullWidth / 2;
+			int halfHeight = m_target.fullHeight / 2;
+
+			int tmpSmallOcclusionRT = AmplifyOcclusionCommon.SafeAllocateTemporaryRT( cb, "_AO_SmallOcclusionTexture",
+																halfWidth, halfHeight,
+																m_occlusionRTFormat,
+																RenderTextureReadWrite.Linear,
+																FilterMode.Bilinear );
+
+			cb.SetGlobalVector( PropertyID._AO_Source_TexelSize, oneOverFullSize_Size );
+			cb.SetGlobalVector( PropertyID._AO_Target_TexelSize, new Vector4( 1.0f / ( m_target.fullWidth / 2.0f ),
+																			  1.0f / ( m_target.fullHeight / 2.0f ),
+																			  m_target.fullWidth / 2.0f,
+																			  m_target.fullHeight / 2.0f ) );
+
+			cb.SetRenderTarget( tmpSmallOcclusionRT );
+			PerformBlit( cb, m_occlusionMat, occlusionPass );
+
+			cb.SetRenderTarget( default( RenderTexture ) );
+			cb.EndSample( "AO 1 - ComputeOcclusion" );
+
+			if( BlurEnabled == true )
+			{
+				commandBuffer_Blur( cb, tmpSmallOcclusionRT, halfWidth, halfHeight );
+			}
+
+			// Combine
+			cb.BeginSample( "AO 2b - Combine" );
+
+			cb.SetGlobalTexture( PropertyID._AO_CurrOcclusionDepth, tmpSmallOcclusionRT );
+
+			cb.SetGlobalVector( PropertyID._AO_Target_TexelSize, oneOverFullSize_Size );
+
+			cb.SetRenderTarget( m_occlusionDepthRT );
+
+			PerformBlit( cb, m_occlusionMat, ShaderPass.CombineDownsampledOcclusionDepth );
+
+			AmplifyOcclusionCommon.SafeReleaseTemporaryRT( cb, tmpSmallOcclusionRT );
+
+			cb.SetRenderTarget( default( RenderTexture ) );
+			cb.EndSample( "AO 2b - Combine" );
+		}
+		else
+		{
+			cb.SetGlobalVector( PropertyID._AO_Source_TexelSize, oneOverFullSize_Size );
+
+			if( UsingFilterDownsample == true )
+			{
+				// Must use proper float precision 2.0 division to avoid artefacts
+				cb.SetGlobalVector( PropertyID._AO_Target_TexelSize, new Vector4( 1.0f / ( m_target.fullWidth / 2.0f ),
+																				  1.0f / ( m_target.fullHeight / 2.0f ),
+																				  m_target.fullWidth / 2.0f,
+																				  m_target.fullHeight / 2.0f ) );
+			}
+			else
+			{
+				cb.SetGlobalVector( PropertyID._AO_Target_TexelSize, new Vector4( 1.0f / (float)m_target.width,
+																				  1.0f / (float)m_target.height,
+																				  m_target.width,
+																				  m_target.height ) );
+			}
+
+			cb.SetRenderTarget( m_occlusionDepthRT );
+			PerformBlit( cb, m_occlusionMat, occlusionPass );
+
+			cb.SetRenderTarget( default( RenderTexture ) );
+			cb.EndSample( "AO 1 - ComputeOcclusion" );
+
+			if( BlurEnabled == true )
+			{
+				commandBuffer_Blur( cb, m_occlusionDepthRT, m_target.width, m_target.height );
+			}
+		}
+	}
+
+
+	int commandBuffer_NeighborMotionIntensity( CommandBuffer cb, int aSourceWidth, int aSourceHeight )
+	{
+		int tmpRT = AmplifyOcclusionCommon.SafeAllocateTemporaryRT( cb, "_AO_IntensityTmp",
+																	aSourceWidth / 4, aSourceHeight / 4,
+																	m_motionIntensityRTFormat,
+																	RenderTextureReadWrite.Linear,
+																	FilterMode.Bilinear );
+
+
+		cb.SetRenderTarget( tmpRT );
+		cb.SetGlobalVector( "_AO_Target_TexelSize", new Vector4( 1.0f / ( aSourceWidth / 4.0f ),
+																 1.0f / ( aSourceHeight / 4.0f ),
+																 aSourceWidth / 4.0f,
+																 aSourceHeight / 4.0f ) );
+
+
+		PerformBlit( cb, m_occlusionMat, ShaderPass.NeighborMotionIntensity );
+
+		int tmpBlurRT = AmplifyOcclusionCommon.SafeAllocateTemporaryRT( cb, "_AO_BlurIntensityTmp",
+																		aSourceWidth / 4, aSourceHeight / 4,
+																		m_motionIntensityRTFormat,
+																		RenderTextureReadWrite.Linear,
+																		FilterMode.Bilinear );
+
+		// Horizontal
+		cb.SetGlobalTexture( PropertyID._AO_CurrMotionIntensity, tmpRT );
+		cb.SetRenderTarget( tmpBlurRT );
+		PerformBlit( cb, m_blurMat, ShaderPass.BlurHorizontalIntensity );
+
+		// Vertical
+		cb.SetGlobalTexture( PropertyID._AO_CurrMotionIntensity, tmpBlurRT );
+		cb.SetRenderTarget( tmpRT );
+		PerformBlit( cb, m_blurMat, ShaderPass.BlurVerticalIntensity );
+
+		AmplifyOcclusionCommon.SafeReleaseTemporaryRT( cb, tmpBlurRT );
+
+		cb.SetGlobalTexture( PropertyID._AO_CurrMotionIntensity, tmpRT );
+
+		return tmpRT;
+	}
+
+
+	void commandBuffer_Blur( CommandBuffer cb, RenderTargetIdentifier aSourceRT, int aSourceWidth, int aSourceHeight )
+	{
+		cb.BeginSample( "AO 2 - Blur" );
+
+		int tmpBlurRT = AmplifyOcclusionCommon.SafeAllocateTemporaryRT( cb, "_AO_BlurTmp",
+																		aSourceWidth, aSourceHeight,
+																		m_occlusionRTFormat,
+																		RenderTextureReadWrite.Linear,
+																		FilterMode.Bilinear );
+
+		// Apply Cross Bilateral Blur
+		for( int i = 0; i < BlurPasses; i++ )
+		{
+			// Horizontal
+			cb.SetGlobalTexture( PropertyID._AO_CurrOcclusionDepth, aSourceRT );
+
+			int blurHorizontalPass = ShaderPass.BlurHorizontal1 + ( BlurRadius - 1 ) * 2;
+
+			cb.SetRenderTarget( tmpBlurRT );
+
+			PerformBlit( cb, m_blurMat, blurHorizontalPass );
+
+
+			// Vertical
+			cb.SetGlobalTexture( PropertyID._AO_CurrOcclusionDepth, tmpBlurRT );
+
+			int blurVerticalPass = ShaderPass.BlurVertical1 + ( BlurRadius - 1 ) * 2;
+
+			cb.SetRenderTarget( aSourceRT );
+
+			PerformBlit( cb, m_blurMat, blurVerticalPass );
+		}
+
+		AmplifyOcclusionCommon.SafeReleaseTemporaryRT( cb, tmpBlurRT );
+
+		cb.SetRenderTarget( default( RenderTexture ) );
+		cb.EndSample( "AO 2 - Blur" );
+	}
+
+	int getTemporalPass()
+	{
+		return ( ( ( UsingMotionVectors == true ) && ( m_sampleStep > 1 ) ) ? ( 1 << 0 ) : 0 );
+	}
+
+	void commandBuffer_TemporalFilter( CommandBuffer cb )
+	{
+		if( m_clearHistory == true )
+		{
+			ClearHistory( cb );
+		}
+
+		// Temporal Filter
+		float temporalAdj = Mathf.Lerp( 0.01f, 0.99f, FilterBlending );
+
+		cb.SetGlobalFloat( PropertyID._AO_TemporalCurveAdj, temporalAdj );
+		cb.SetGlobalFloat( PropertyID._AO_TemporalMotionSensibility, FilterResponse * FilterResponse + 0.01f );
+
+		cb.SetGlobalTexture( PropertyID._AO_CurrOcclusionDepth, m_occlusionDepthRT );
+		cb.SetGlobalTexture( PropertyID._AO_TemporalAccumm, m_temporalAccumRT[ m_prevTemporalIdx ] );
+	}
+
+	private readonly RenderTargetIdentifier[] m_applyDeferredTargets =
+	{
+		BuiltinRenderTextureType.GBuffer0,		// RGB: Albedo, A: Occ
+		BuiltinRenderTextureType.CameraTarget,	// RGB: Emission, A: None
+	};
+
+	private readonly RenderTargetIdentifier[] m_applyDeferredTargets_Log =
+	{
+		BuiltinRenderTextureType.GBuffer0,		// RGB: Albedo, A: Occ
+		BuiltinRenderTextureType.GBuffer3		// RGB: Emission, A: None
+	};
+
+	void commandBuffer_FillApplyDeferred( CommandBuffer cb, bool logTarget )
+	{
+		cb.BeginSample( "AO 3 - ApplyDeferred" );
+
+		if( !logTarget )
+		{
+			if( UsingTemporalFilter )
+			{
+				commandBuffer_TemporalFilter( cb );
+
+				int tmpMotionIntensityRT = 0;
+
+				if( UsingMotionVectors == true )
+				{
+					tmpMotionIntensityRT = commandBuffer_NeighborMotionIntensity( cb, m_target.fullWidth, m_target.fullHeight );
+				}
+
+				if( UsingFilterDownsample == false )
+				{
+					int applyOcclusionRT = 0;
+					if ( useMRTBlendingFallback )
+					{
+						applyOcclusionRT = AmplifyOcclusionCommon.SafeAllocateTemporaryRT( cb, "_AO_ApplyOcclusionTexture", m_target.fullWidth, m_target.fullHeight, RenderTextureFormat.ARGB32 );
+
+						applyOcclusionTemporal[0] = applyOcclusionRT;
+						applyOcclusionTemporal[1] = new RenderTargetIdentifier( m_temporalAccumRT[ m_curTemporalIdx ] );
+
+						cb.SetRenderTarget( applyOcclusionTemporal, applyOcclusionTemporal[ 0 ] /* Not used, just to make Unity happy */ );
+						PerformBlit( cb, m_applyOcclusionMat, ShaderPass.ApplyPostEffectTemporal + getTemporalPass() ); // re-use ApplyPostEffectTemporal pass to apply without Blend to the RT.
+					}
+					else
+					{
+						applyDeferredTargetsTemporal[0] = m_applyDeferredTargets[0];
+						applyDeferredTargetsTemporal[1] = m_applyDeferredTargets[1];
+						applyDeferredTargetsTemporal[2] = new RenderTargetIdentifier( m_temporalAccumRT[ m_curTemporalIdx ] );
+
+						cb.SetRenderTarget( applyDeferredTargetsTemporal, applyDeferredTargetsTemporal[ 0 ] /* Not used, just to make Unity happy */ );
+						PerformBlit( cb, m_applyOcclusionMat, ShaderPass.ApplyDeferredTemporal + getTemporalPass() );
+					}
+
+					if ( useMRTBlendingFallback )
+					{
+						cb.SetGlobalTexture( "_AO_ApplyOcclusionTexture", applyOcclusionRT );
+
+						applyOcclusionTemporal[0] = m_applyDeferredTargets[0];
+						applyOcclusionTemporal[1] = m_applyDeferredTargets[1];
+
+						cb.SetRenderTarget( applyOcclusionTemporal, applyOcclusionTemporal[ 0 ] /* Not used, just to make Unity happy */ );
+						PerformBlit( cb, m_applyOcclusionMat, ShaderPass.ApplyDeferredTemporalMultiply );
+
+						AmplifyOcclusionCommon.SafeReleaseTemporaryRT( cb, applyOcclusionRT );
+					}
+				}
+				else
+				{
+					// UsingFilterDownsample == true
+
+					RenderTargetIdentifier temporalRTid = new RenderTargetIdentifier( m_temporalAccumRT[ m_curTemporalIdx ] );
+
+					cb.SetRenderTarget( temporalRTid );
+					PerformBlit( cb, m_occlusionMat, ShaderPass.Temporal + getTemporalPass() );
+
+					cb.SetGlobalTexture( PropertyID._AO_TemporalAccumm, temporalRTid );
+					cb.SetRenderTarget( m_applyDeferredTargets, m_applyDeferredTargets[ 0 ] /* Not used, just to make Unity happy */ );
+					PerformBlit( cb, m_applyOcclusionMat, ShaderPass.ApplyDeferredCombineFromTemporal );
+				}
+
+				if( UsingMotionVectors == true )
+				{
+					AmplifyOcclusionCommon.SafeReleaseTemporaryRT( cb, tmpMotionIntensityRT );
+				}
+			}
+			else
+			{
+				cb.SetGlobalTexture( PropertyID._AO_CurrOcclusionDepth, m_occlusionDepthRT );
+
+				// Multiply Occlusion
+				cb.SetRenderTarget( m_applyDeferredTargets, m_applyDeferredTargets[ 0 ] /* Not used, just to make Unity happy */ );
+				PerformBlit( cb, m_applyOcclusionMat, ShaderPass.ApplyDeferred );
+			}
+		}
+		else
+		{
+			// Copy Albedo and Emission to temporary buffers
+			int gbufferAlbedoRT = AmplifyOcclusionCommon.SafeAllocateTemporaryRT( cb, "_AO_tmpAlbedo",
+																					m_target.fullWidth, m_target.fullHeight,
+																					RenderTextureFormat.ARGB32 );
+
+			int gbufferEmissionRT = AmplifyOcclusionCommon.SafeAllocateTemporaryRT( cb, "_AO_tmpEmission",
+																					m_target.fullWidth, m_target.fullHeight,
+																					m_temporaryEmissionRTFormat );
+
+			cb.Blit( BuiltinRenderTextureType.GBuffer0, gbufferAlbedoRT );
+			cb.Blit( BuiltinRenderTextureType.GBuffer3, gbufferEmissionRT );
+
+			cb.SetGlobalTexture( PropertyID._AO_GBufferAlbedo, gbufferAlbedoRT );
+			cb.SetGlobalTexture( PropertyID._AO_GBufferEmission, gbufferEmissionRT );
+
+			if( UsingTemporalFilter )
+			{
+				commandBuffer_TemporalFilter( cb );
+
+				int tmpMotionIntensityRT = 0;
+
+				if( UsingMotionVectors == true )
+				{
+					tmpMotionIntensityRT = commandBuffer_NeighborMotionIntensity( cb, m_target.fullWidth, m_target.fullHeight );
+				}
+
+				if( UsingFilterDownsample == false )
+				{
+					applyDeferredTargets_Log_Temporal[0] = m_applyDeferredTargets_Log[0];
+					applyDeferredTargets_Log_Temporal[1] = m_applyDeferredTargets_Log[1];
+					applyDeferredTargets_Log_Temporal[2] = new RenderTargetIdentifier( m_temporalAccumRT[ m_curTemporalIdx ] );
+
+					cb.SetRenderTarget( applyDeferredTargets_Log_Temporal, applyDeferredTargets_Log_Temporal[ 0 ] /* Not used, just to make Unity happy */ );
+					PerformBlit( cb, m_applyOcclusionMat, ShaderPass.ApplyDeferredLogTemporal + getTemporalPass() );
+				}
+				else
+				{
+					// UsingFilterDownsample == true
+
+					RenderTargetIdentifier temporalRTid = new RenderTargetIdentifier( m_temporalAccumRT[ m_curTemporalIdx ] );
+
+					cb.SetRenderTarget( temporalRTid );
+					PerformBlit( cb, m_occlusionMat, ShaderPass.Temporal + getTemporalPass() );
+
+					cb.SetGlobalTexture( PropertyID._AO_TemporalAccumm, temporalRTid );
+					cb.SetRenderTarget( m_applyDeferredTargets_Log, m_applyDeferredTargets_Log[ 0 ] /* Not used, just to make Unity happy */ );
+					PerformBlit( cb, m_applyOcclusionMat, ShaderPass.ApplyDeferredLogCombineFromTemporal );
+				}
+
+				if( UsingMotionVectors == true )
+				{
+					AmplifyOcclusionCommon.SafeReleaseTemporaryRT( cb, tmpMotionIntensityRT );
+				}
+			}
+			else
+			{
+				cb.SetGlobalTexture( PropertyID._AO_CurrOcclusionDepth, m_occlusionDepthRT );
+
+				cb.SetRenderTarget( m_applyDeferredTargets_Log, m_applyDeferredTargets_Log[ 0 ] /* Not used, just to make Unity happy */ );
+				PerformBlit( cb, m_applyOcclusionMat, ShaderPass.ApplyDeferredLog );
+			}
+
+			AmplifyOcclusionCommon.SafeReleaseTemporaryRT( cb, gbufferAlbedoRT );
+			AmplifyOcclusionCommon.SafeReleaseTemporaryRT( cb, gbufferEmissionRT );
+		}
+
+		cb.SetRenderTarget( default( RenderTexture ) );
+		cb.EndSample( "AO 3 - ApplyDeferred" );
+	}
+
+
+	void commandBuffer_FillApplyPostEffect( CommandBuffer cb )
+	{
+		cb.BeginSample( "AO 3 - ApplyPostEffect" );
+
+		if( UsingTemporalFilter )
+		{
+			commandBuffer_TemporalFilter( cb );
+
+			int tmpMotionIntensityRT = 0;
+
+			if( UsingMotionVectors == true )
+			{
+				tmpMotionIntensityRT = commandBuffer_NeighborMotionIntensity( cb, m_target.fullWidth, m_target.fullHeight );
+			}
+
+			if( UsingFilterDownsample == false )
+			{
+				int applyOcclusionRT = 0;
+				if ( useMRTBlendingFallback )
+				{
+					applyOcclusionRT = AmplifyOcclusionCommon.SafeAllocateTemporaryRT( cb, "_AO_ApplyOcclusionTexture", m_target.fullWidth, m_target.fullHeight, RenderTextureFormat.ARGB32 );
+					applyPostEffectTargetsTemporal[ 0 ] = applyOcclusionRT;
+				}
+				else
+				{
+					applyPostEffectTargetsTemporal[ 0 ] = BuiltinRenderTextureType.CameraTarget;
+				}
+
+				applyPostEffectTargetsTemporal[1] = new RenderTargetIdentifier( m_temporalAccumRT[ m_curTemporalIdx ] );
+
+				cb.SetRenderTarget( applyPostEffectTargetsTemporal, applyPostEffectTargetsTemporal[ 0 ] /* Not used, just to make Unity happy */ );
+				PerformBlit( cb, m_applyOcclusionMat, ShaderPass.ApplyPostEffectTemporal + getTemporalPass() );
+
+				if ( useMRTBlendingFallback )
+				{
+					cb.SetGlobalTexture( "_AO_ApplyOcclusionTexture", applyOcclusionRT );
+
+					cb.SetRenderTarget( BuiltinRenderTextureType.CameraTarget );
+					PerformBlit( cb, m_applyOcclusionMat, ShaderPass.ApplyPostEffectTemporalMultiply );
+
+					AmplifyOcclusionCommon.SafeReleaseTemporaryRT( cb, applyOcclusionRT );
+				}
+			}
+			else
+			{
+				// UsingFilterDownsample == true
+
+				RenderTargetIdentifier temporalRTid = new RenderTargetIdentifier( m_temporalAccumRT[ m_curTemporalIdx ] );
+
+				cb.SetRenderTarget( temporalRTid );
+				PerformBlit( cb, m_occlusionMat, ShaderPass.Temporal + getTemporalPass() );
+
+				cb.SetGlobalTexture( PropertyID._AO_TemporalAccumm, temporalRTid );
+				cb.SetRenderTarget( BuiltinRenderTextureType.CameraTarget );
+				PerformBlit( cb, m_applyOcclusionMat, ShaderPass.ApplyCombineFromTemporal );
+			}
+
+			if( UsingMotionVectors == true )
+			{
+				AmplifyOcclusionCommon.SafeReleaseTemporaryRT( cb, tmpMotionIntensityRT );
+			}
+		}
+		else
+		{
+			cb.SetGlobalTexture( PropertyID._AO_CurrOcclusionDepth, m_occlusionDepthRT );
+
+			cb.SetRenderTarget( BuiltinRenderTextureType.CameraTarget );
+			PerformBlit( cb, m_applyOcclusionMat, ShaderPass.ApplyPostEffect );
+		}
+
+		cb.SetRenderTarget( default( RenderTexture ) );
+		cb.EndSample( "AO 3 - ApplyPostEffect" );
+	}
+
+
+	void commandBuffer_FillApplyDebug( CommandBuffer cb )
+	{
+		cb.BeginSample( "AO 3 - ApplyDebug" );
+
+		if( UsingTemporalFilter )
+		{
+			commandBuffer_TemporalFilter( cb );
+
+			int tmpMotionIntensityRT = 0;
+
+			if( UsingMotionVectors == true )
+			{
+				tmpMotionIntensityRT = commandBuffer_NeighborMotionIntensity( cb, m_target.fullWidth, m_target.fullHeight );
+			}
+
+			if( UsingFilterDownsample == false )
+			{
+				applyDebugTargetsTemporal[0] = BuiltinRenderTextureType.CameraTarget;
+				applyDebugTargetsTemporal[1] = new RenderTargetIdentifier( m_temporalAccumRT[ m_curTemporalIdx ] );
+
+				cb.SetRenderTarget( applyDebugTargetsTemporal, applyDebugTargetsTemporal[ 0 ] /* Not used, just to make Unity happy */ );
+				PerformBlit( cb, m_applyOcclusionMat, ShaderPass.ApplyDebugTemporal + getTemporalPass() );
+			}
+			else
+			{
+				// UsingFilterDownsample == true
+
+				RenderTargetIdentifier temporalRTid = new RenderTargetIdentifier( m_temporalAccumRT[ m_curTemporalIdx ] );
+
+				cb.SetRenderTarget( temporalRTid );
+				PerformBlit( cb, m_occlusionMat, ShaderPass.Temporal + getTemporalPass() );
+
+				cb.SetGlobalTexture( PropertyID._AO_TemporalAccumm, temporalRTid );
+				cb.SetRenderTarget( BuiltinRenderTextureType.CameraTarget );
+				PerformBlit( cb, m_applyOcclusionMat, ShaderPass.ApplyDebugCombineFromTemporal );
+			}
+
+			if( UsingMotionVectors == true )
+			{
+				AmplifyOcclusionCommon.SafeReleaseTemporaryRT( cb, tmpMotionIntensityRT );
+			}
+		}
+		else
+		{
+			cb.SetGlobalTexture( PropertyID._AO_CurrOcclusionDepth, m_occlusionDepthRT );
+
+			cb.SetRenderTarget( BuiltinRenderTextureType.CameraTarget );
+			PerformBlit( cb, m_applyOcclusionMat, ShaderPass.ApplyDebug );
+		}
+
+		cb.SetRenderTarget( default( RenderTexture ) );
+		cb.EndSample( "AO 3 - ApplyDebug" );
+	}
+
+	private TargetDesc m_target = new TargetDesc();
+
+	void UpdateGlobalShaderConstants( CommandBuffer cb )
+	{
+		AmplifyOcclusionCommon.UpdateGlobalShaderConstants( cb, ref m_target, m_targetCamera, Downsample, UsingFilterDownsample );
+	}
+
+	void UpdateGlobalShaderConstants_AmbientOcclusion( CommandBuffer cb )
+	{
+		// Ambient Occlusion
+		cb.SetGlobalFloat( PropertyID._AO_Radius, Radius );
+		cb.SetGlobalFloat( PropertyID._AO_PowExponent, PowerExponent );
+		cb.SetGlobalFloat( PropertyID._AO_Bias, Bias * Bias );
+		cb.SetGlobalColor( PropertyID._AO_Levels, new Color( Tint.r, Tint.g, Tint.b, Intensity ) );
+
+		float invThickness = ( 1.0f - Thickness );
+		cb.SetGlobalFloat( PropertyID._AO_ThicknessDecay, ( 1.0f - invThickness * invThickness ) * 0.98f );
+
+		float AO_BufDepthToLinearEye = m_targetCamera.farClipPlane * m_oneOverDepthScale;
+		cb.SetGlobalFloat( PropertyID._AO_BufDepthToLinearEye, AO_BufDepthToLinearEye );
+
+		if( BlurEnabled == true )
+		{
+			float AO_BlurSharpness = BlurSharpness * 100.0f * AO_BufDepthToLinearEye;
+
+			cb.SetGlobalFloat( PropertyID._AO_BlurSharpness, AO_BlurSharpness );
+		}
+
+		// Distance Fade
+		if( FadeEnabled == true )
+		{
+			FadeStart = Mathf.Max( 0.0f, FadeStart );
+			FadeLength = Mathf.Max( 0.01f, FadeLength );
+
+			float rcpFadeLength = 1.0f / FadeLength;
+
+			cb.SetGlobalVector( PropertyID._AO_FadeParams, new Vector2( FadeStart, rcpFadeLength ) );
+			float invFadeThickness = ( 1.0f - FadeToThickness );
+			cb.SetGlobalVector( PropertyID._AO_FadeValues, new Vector4( FadeToIntensity, FadeToRadius, FadeToPowerExponent, ( 1.0f - invFadeThickness * invFadeThickness ) * 0.98f ) );
+			cb.SetGlobalColor( PropertyID._AO_FadeToTint, new Color( FadeToTint.r, FadeToTint.g, FadeToTint.b, 0.0f ) );
+		}
+		else
+		{
+			cb.SetGlobalVector( PropertyID._AO_FadeParams, new Vector2( 0.0f, 0.0f ) );
+		}
+
+		if( UsingTemporalFilter == true )
+		{
+			AmplifyOcclusionCommon.CommandBuffer_TemporalFilterDirectionsOffsets( cb, m_sampleStep );
+		}
+		else
+		{
+			cb.SetGlobalFloat( PropertyID._AO_TemporalDirections, 0 );
+			cb.SetGlobalFloat( PropertyID._AO_TemporalOffsets, 0 );
+		}
+	}
+
+	AmplifyOcclusionViewProjMatrix m_viewProjMatrix = new AmplifyOcclusionViewProjMatrix();
+	void UpdateGlobalShaderConstants_Matrices( CommandBuffer cb )
+	{
+		m_viewProjMatrix.UpdateGlobalShaderConstants_Matrices( cb, m_targetCamera, UsingTemporalFilter );
+	}
+}

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Plugins/AmplifyOcclusionEffect.cs.meta
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Plugins/AmplifyOcclusionEffect.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 6a879e317c20b0d41a9a56f1a97f4cf8
+timeCreated: 1452773390
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 02279d0f85b95124a85f8cbf24716a1b, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Plugins/SRP.meta
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Plugins/SRP.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7ee226cdeea00e048a1e53df83876545
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Plugins/SRP/AmplifyOcclusionRenderer.cs
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Plugins/SRP/AmplifyOcclusionRenderer.cs
@@ -1,0 +1,855 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.Universal;
+
+namespace AmplifyOcclusion
+{
+    public class AmplifyOcclusionRenderer : ScriptableRendererFeature
+    {
+        AmplifyOcclusionRenderPass renderPass;
+
+        public override void Create()
+        {
+            if (renderPass == null)
+                renderPass = new AmplifyOcclusionRenderPass();
+        }
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                renderPass?.Dispose();
+        }
+
+        public override void AddRenderPasses(ScriptableRenderer renderer, ref RenderingData renderingData)
+        {
+            //if (renderingData.cameraData.postProcessEnabled)
+            renderer.EnqueuePass(renderPass);
+        }
+
+        class AmplifyOcclusionRenderPass : ScriptableRenderPass
+        {
+            public AmplifyOcclusionVolume settings;
+
+            // Current state variables
+            private bool m_HDR = true;
+            private bool m_MSAA = true;
+
+            // Previous state variables
+            private SampleCountLevel m_prevSampleCount = SampleCountLevel.Low;
+            private bool m_prevDownsample = false;
+            private bool m_prevCacheAware = false;
+            private bool m_prevBlurEnabled = false;
+            private int m_prevBlurRadius = 0;
+            private int m_prevBlurPasses = 0;
+            private bool m_prevFilterEnabled = true;
+            private bool m_prevFilterDownsample = true;
+            private bool m_prevHDR = true;
+            private bool m_prevMSAA = true;
+
+            private RenderTargetIdentifier[] applyDebugTargetsTemporal = new RenderTargetIdentifier[2];
+            private RenderTargetIdentifier[] applyPostEffectTargetsTemporal = new RenderTargetIdentifier[2];
+
+            private bool m_isSceneView = false;
+            //private bool UsingTemporalFilter { get { return ((settings.FilterEnabled == true) && (m_isSceneView == false)); } }
+            //private bool UsingFilterDownsample { get { return (settings.Downsample == true) && (settings.FilterDownsample == true) && (UsingTemporalFilter == true); } }
+            private bool UsingMotionVectors = false;
+            private bool m_paramsChanged = true;
+            private bool m_clearHistory = true;
+
+            private float m_oneOverDepthScale = (1.0f / 65504.0f); // 65504.0f max half float
+            private Camera camera;
+            private CameraData cameraData;
+            private RenderTargetIdentifier source;
+
+            static private Mesh m_quadMesh = null;
+            static Texture2D defaultRampTex;
+
+            private void createDefaultRamp()
+            {
+                if (defaultRampTex != null)
+                    return;
+                const int width = 128;
+                defaultRampTex = new Texture2D(width, 1, TextureFormat.RGBA32, false);
+                var gradient = new Gradient() { colorKeys = new GradientColorKey[] { 
+                    new GradientColorKey(new Color(0, 0, 0, 1), 0), 
+                    new GradientColorKey(new Color(1, 1, 1, 1), 1), 
+                    }};
+                for (int x = 0; x < width; x++)
+                    defaultRampTex.SetPixel(x, 0, gradient.Evaluate((float)x / width));
+                defaultRampTex.Apply(false, true);
+            }
+            private void createQuadMesh()
+            {
+                if (m_quadMesh != null)
+                    return;
+                m_quadMesh = new Mesh();
+                m_quadMesh.vertices = new Vector3[] {
+                    new Vector3(-1,-1,0.5f),
+                    new Vector3(-1,1,0.5f),
+                    new Vector3(1,1,0.5f),
+                    new Vector3(1,-1,0.5f)
+                };
+                m_quadMesh.uv = new Vector2[] {
+                    new Vector2(0,1),
+                    new Vector2(0,0),
+                    new Vector2(1,0),
+                    new Vector2(1,1)
+                };
+                m_quadMesh.SetIndices(new int[] { 0, 1, 2, 3 }, MeshTopology.Quads, 0);
+            }
+
+            public override void OnCameraSetup(CommandBuffer cmd, ref RenderingData renderingData)
+            {
+                cameraData = renderingData.cameraData;
+                camera = cameraData.camera;
+                source = cameraData.renderer.cameraColorTarget;
+                if (camera.cameraType != CameraType.Game)
+                    return;
+                //var renderer = renderingData.cameraData.renderer;
+                //ConfigureTarget(renderer.cameraColorTargetHandle, renderer.cameraDepthTargetHandle);
+
+                settings = VolumeManager.instance.stack.GetComponent<AmplifyOcclusionVolume>();
+
+                createQuadMesh();
+                createDefaultRamp();
+                checkMaterials(true);
+                UpdateGlobalShaderConstants(cmd, camera);
+                checkParamsChanged(camera);
+                UpdateGlobalShaderConstants_AmbientOcclusion(cmd, camera);
+                updateParams();
+
+                Shader.SetGlobalFloat("_RenderViewportScaleFactor", 1.0f);
+
+                var rampTex = settings.RampTexture.value;
+                m_applyOcclusionMat.SetTexture("_OcclusionRamp", rampTex == null ? defaultRampTex : rampTex );
+
+                //renderPassEvent = AfterOpaque ? RenderPassEvent.AfterRenderingOpaques : RenderPassEvent.AfterRenderingPrePasses + 1;
+
+                //ConfigureInput(ScriptableRenderPassInput.Color);
+                ConfigureInput(ScriptableRenderPassInput.Depth);
+                //ConfigureInput(ScriptableRenderPassInput.Normal);
+
+            }
+
+            public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
+            {
+                if (camera.cameraType != CameraType.Game)
+                    return;
+                m_isSceneView = camera.cameraType == CameraType.SceneView;
+
+                if (settings == null || !settings.IsActive())
+                    return;
+
+                var cmd = CommandBufferPool.Get("AmplifyOcclusion");
+                cmd.Clear();
+                cmd.BeginSample("AO - Render");
+
+                m_curStepIdx = m_sampleStep & 1;
+
+                UpdateGlobalShaderConstants_Matrices(cmd, camera);
+
+                commandBuffer_FillComputeOcclusion(cmd);
+
+                if (settings.ApplyMethod == AmplifyOcclusionVolume.ApplicationMethod.Debug)
+                {
+                    commandBuffer_FillApplyDebug(cmd, source, source);
+                }
+                else
+                {
+                    //commandBuffer_FillApplyDebug(cmd, source, source);
+                    commandBuffer_FillApplyPostEffect(cmd, source, source, ref renderingData);
+                }
+
+                m_sampleStep++; // No clamp, free running counter
+
+                cmd.EndSample("AO - Render");
+
+                context.ExecuteCommandBuffer(cmd);
+                CommandBufferPool.Release(cmd);
+            }
+
+            public void Dispose()
+            {
+                AmplifyOcclusionCommon.SafeReleaseRT(ref m_occlusionDepthRT);
+                AmplifyOcclusionCommon.SafeReleaseRT(ref m_depthMipmap);
+                releaseTemporalRT();
+            }
+
+            private TargetDesc m_target = new TargetDesc();
+
+            private static readonly int id_ScreenToTargetScale = Shader.PropertyToID("_ScreenToTargetScale");
+
+            void UpdateGlobalShaderConstants(CommandBuffer cb, Camera aCamera)
+            {
+                AmplifyOcclusionCommon.UpdateGlobalShaderConstants(cb, ref m_target, aCamera, settings.Downsample.value, false); // UsingTemporalFilter
+
+                //if( m_hdRender == null )
+                //{
+                // HDSRP _ScreenToTargetScale = { w / RTHandle.maxWidth, h / RTHandle.maxHeight } : xy = currFrame, zw = prevFram
+                // Fill _ScreenToTargetScale for LWSRP
+                cb.SetGlobalVector(id_ScreenToTargetScale, new Vector4(1.0f, 1.0f, 1.0f, 1.0f));
+                //}
+            }
+
+            void UpdateGlobalShaderConstants_AmbientOcclusion(CommandBuffer cb, Camera aCamera)
+            {
+                // Ambient Occlusion
+                cb.SetGlobalFloat(PropertyID._AO_Radius, settings.Radius.value);
+                cb.SetGlobalFloat(PropertyID._AO_PowExponent, settings.PowerExponent.value);
+                cb.SetGlobalFloat(PropertyID._AO_Bias, settings.Bias.value * settings.Bias.value);
+                cb.SetGlobalColor(PropertyID._AO_Levels, new Color(settings.Tint.value.r, settings.Tint.value.g, settings.Tint.value.b, settings.Intensity.value));
+
+                float invThickness = (1.0f - settings.Thickness.value);
+                cb.SetGlobalFloat(PropertyID._AO_ThicknessDecay, (1.0f - invThickness * invThickness) * 0.98f);
+
+                float AO_BufDepthToLinearEye = aCamera.farClipPlane * m_oneOverDepthScale;
+                cb.SetGlobalFloat(PropertyID._AO_BufDepthToLinearEye, AO_BufDepthToLinearEye);
+
+                if (settings.BlurEnabled == true)
+                {
+                    float AO_BlurSharpness = settings.BlurSharpness.value * 100.0f * AO_BufDepthToLinearEye;
+
+                    cb.SetGlobalFloat(PropertyID._AO_BlurSharpness, AO_BlurSharpness);
+                }
+
+                // Distance Fade
+                if (settings.FadeEnabled == true)
+                {
+                    settings.FadeStart.value = Mathf.Max(0.0f, settings.FadeStart.value);
+                    settings.FadeLength.value = Mathf.Max(0.01f, settings.FadeLength.value);
+
+                    float rcpFadeLength = 1.0f / settings.FadeLength.value;
+
+                    cb.SetGlobalVector(PropertyID._AO_FadeParams, new Vector2(settings.FadeStart.value, rcpFadeLength));
+                    float invFadeThickness = (1.0f - settings.FadeToThickness.value);
+                    cb.SetGlobalVector(PropertyID._AO_FadeValues, new Vector4(settings.FadeToIntensity.value, settings.FadeToRadius.value, settings.FadeToPowerExponent.value, (1.0f - invFadeThickness * invFadeThickness) * 0.98f));
+                    cb.SetGlobalColor(PropertyID._AO_FadeToTint, new Color(settings.FadeToTint.value.r, settings.FadeToTint.value.g, settings.FadeToTint.value.b, 0.0f));
+                }
+                else
+                {
+                    cb.SetGlobalVector(PropertyID._AO_FadeParams, new Vector2(0.0f, 0.0f));
+                }
+                /*
+                                if (UsingTemporalFilter == true)
+                                {
+                                    AmplifyOcclusionCommon.CommandBuffer_TemporalFilterDirectionsOffsets(cb, m_sampleStep);
+                                }
+                                else*/
+                {
+                    cb.SetGlobalFloat(PropertyID._AO_TemporalDirections, 0);
+                    cb.SetGlobalFloat(PropertyID._AO_TemporalOffsets, 0);
+                }
+            }
+
+
+            private AmplifyOcclusionViewProjMatrix m_viewProjMatrix = new AmplifyOcclusionViewProjMatrix();
+
+            void UpdateGlobalShaderConstants_Matrices(CommandBuffer cb, Camera aCamera)
+            {
+                m_viewProjMatrix.UpdateGlobalShaderConstants_Matrices(cb, aCamera, false); // UsingTemporalFilter
+            }
+
+
+            void PerformBlit(CommandBuffer cb, RenderTargetIdentifier destination, Material mat, int pass)
+            {
+                //Blit(cb, source, destination, mat, pass);
+                //CoreUtils.SetRenderTarget(cb, destination);
+                cb.SetRenderTarget(destination);
+                //cb.SetRenderTargetWithLoadStoreAction(destination, RenderBufferLoadAction.DontCare, RenderBufferStoreAction.Store);
+                cb.DrawMesh(m_quadMesh, Matrix4x4.identity, mat, 0, pass);
+                //CoreUtils.DrawFullScreen(cb, mat, pass);
+            }
+            void PerformBlit(CommandBuffer cb, Material mat, int pass)
+            {
+                cb.DrawMesh(m_quadMesh, Matrix4x4.identity, mat, 0, pass);
+            }
+
+            // Render Materials
+            static private Material m_occlusionMat = null;
+            static private Material m_blurMat = null;
+            static private Material m_applyOcclusionMat = null;
+
+            private void checkMaterials(bool aThroughErrorMsg)
+            {
+                if (m_occlusionMat == null)
+                {
+                    m_occlusionMat = AmplifyOcclusionCommon.CreateMaterialWithShaderName("Hidden/Amplify Occlusion/OcclusionPostProcessing", aThroughErrorMsg);
+                }
+
+                if (m_blurMat == null)
+                {
+                    m_blurMat = AmplifyOcclusionCommon.CreateMaterialWithShaderName("Hidden/Amplify Occlusion/BlurPostProcessing", aThroughErrorMsg);
+                }
+
+                if (m_applyOcclusionMat == null)
+                {
+                    m_applyOcclusionMat = AmplifyOcclusionCommon.CreateMaterialWithShaderName("Hidden/Amplify Occlusion/ApplyPostProcessing", aThroughErrorMsg);
+                }
+            }
+
+
+            private RenderTextureFormat m_occlusionRTFormat = RenderTextureFormat.RGHalf;
+            //private RenderTextureFormat m_occlusionRTFormat = RenderTextureFormat.RGHalf;
+            private RenderTextureFormat m_accumTemporalRTFormat = RenderTextureFormat.ARGB32;
+            private RenderTextureFormat m_motionIntensityRTFormat = RenderTextureFormat.R8;
+
+            private bool checkRenderTextureFormats()
+            {
+                // test the two fallback formats first
+                if (SystemInfo.SupportsRenderTextureFormat(RenderTextureFormat.ARGB32) && SystemInfo.SupportsRenderTextureFormat(RenderTextureFormat.ARGBHalf))
+                {
+                    m_occlusionRTFormat = RenderTextureFormat.RGHalf;
+                    if (!SystemInfo.SupportsRenderTextureFormat(m_occlusionRTFormat))
+                    {
+                        m_occlusionRTFormat = RenderTextureFormat.RGFloat;
+                        if (!SystemInfo.SupportsRenderTextureFormat(m_occlusionRTFormat))
+                        {
+                            // already tested above
+                            m_occlusionRTFormat = RenderTextureFormat.ARGBHalf;
+                        }
+                    }
+
+                    return true;
+                }
+                return false;
+            }
+
+            private RenderTexture m_occlusionDepthRT = null;
+            private RenderTexture[] m_temporalAccumRT = null;
+            private RenderTexture m_depthMipmap = null;
+
+            private uint m_sampleStep = 0;
+            private uint m_curStepIdx = 0;
+            private string[] m_tmpMipString = null;
+            private int m_numberMips = 0;
+
+            private void commandBuffer_FillComputeOcclusion(CommandBuffer cb)
+            {
+                cb.BeginSample("AO 1 - ComputeOcclusion");
+
+                Vector4 oneOverFullSize_Size = new Vector4(1.0f / (float)m_target.fullWidth,
+                                                            1.0f / (float)m_target.fullHeight,
+                                                            m_target.fullWidth,
+                                                            m_target.fullHeight);
+
+                int sampleCountPass = ((int)settings.SampleCount.value) * AmplifyOcclusionCommon.PerPixelNormalSourceCount;
+
+                int occlusionPass = (ShaderPass.OcclusionLow_None +
+                                      sampleCountPass +
+                                      ShaderPass.OcclusionLow_None);
+                //((settings.PerPixelNormals == PerPixelNormalSource.None) ? ShaderPass.OcclusionLow_None : ShaderPass.OcclusionLow_GBufferOctaEncoded));
+
+
+                if (settings.CacheAware == true)
+                {
+                    occlusionPass += ShaderPass.OcclusionLow_None_UseDynamicDepthMips;
+
+                    // Construct Depth mipmaps
+                    int previouslyTmpMipRT = 0;
+
+                    for (int i = 0; i < m_numberMips; i++)
+                    {
+                        int tmpMipRT;
+
+                        int width = m_target.fullWidth >> (i + 1);
+                        int height = m_target.fullHeight >> (i + 1);
+
+                        tmpMipRT = AmplifyOcclusionCommon.SafeAllocateTemporaryRT(cb, m_tmpMipString[i],
+                                                                                    width, height,
+                                                                                    RenderTextureFormat.RFloat,
+                                                                                    RenderTextureReadWrite.Linear,
+                                                                                    FilterMode.Bilinear);
+
+                        // _AO_CurrDepthSource was previously set
+                        cb.SetRenderTarget(tmpMipRT);
+
+                        PerformBlit(cb, m_occlusionMat, ((i == 0) ? ShaderPass.ScaleDownCloserDepthEven_CameraDepthTexture : ShaderPass.ScaleDownCloserDepthEven));
+
+                        cb.CopyTexture(tmpMipRT, 0, 0, m_depthMipmap, 0, i);
+
+                        if (previouslyTmpMipRT != 0)
+                        {
+                            AmplifyOcclusionCommon.SafeReleaseTemporaryRT(cb, previouslyTmpMipRT);
+                        }
+
+                        previouslyTmpMipRT = tmpMipRT;
+
+                        cb.SetGlobalTexture(PropertyID._AO_CurrDepthSource, tmpMipRT); // Set next MipRT ID
+                    }
+
+                    AmplifyOcclusionCommon.SafeReleaseTemporaryRT(cb, previouslyTmpMipRT);
+
+                    cb.SetGlobalTexture(PropertyID._AO_SourceDepthMipmap, m_depthMipmap);
+                }
+
+
+                //if ((settings.Downsample == true) && (UsingFilterDownsample == false))
+                if (settings.Downsample == true)
+                {
+                    int halfWidth = m_target.fullWidth / 2;
+                    int halfHeight = m_target.fullHeight / 2;
+
+                    int tmpSmallOcclusionRT = AmplifyOcclusionCommon.SafeAllocateTemporaryRT(cb, "_AO_SmallOcclusionTexture",
+                                                                                                halfWidth, halfHeight,
+                                                                                                m_occlusionRTFormat,
+                                                                                                RenderTextureReadWrite.Linear,
+                                                                                                FilterMode.Bilinear);
+
+
+                    cb.SetGlobalVector(PropertyID._AO_Target_TexelSize, new Vector4(1.0f / (m_target.fullWidth / 2.0f),
+                                                                                    1.0f / (m_target.fullHeight / 2.0f),
+                                                                                    m_target.fullWidth / 2.0f,
+                                                                                    m_target.fullHeight / 2.0f));
+
+                    PerformBlit(cb, tmpSmallOcclusionRT, m_occlusionMat, occlusionPass);
+
+                    cb.SetRenderTarget(default(RenderTexture));
+                    cb.EndSample("AO 1 - ComputeOcclusion");
+
+                    if (settings.BlurEnabled == true)
+                    {
+                        commandBuffer_Blur(cb, tmpSmallOcclusionRT, halfWidth, halfHeight);
+                    }
+
+                    // Combine
+                    cb.BeginSample("AO 2b - Combine");
+
+                    cb.SetGlobalTexture(PropertyID._AO_CurrOcclusionDepth, tmpSmallOcclusionRT);
+
+                    cb.SetGlobalVector(PropertyID._AO_Target_TexelSize, oneOverFullSize_Size);
+
+                    PerformBlit(cb, m_occlusionDepthRT, m_occlusionMat, ShaderPass.CombineDownsampledOcclusionDepth);
+
+                    AmplifyOcclusionCommon.SafeReleaseTemporaryRT(cb, tmpSmallOcclusionRT);
+
+                    cb.SetRenderTarget(default(RenderTexture));
+                    cb.EndSample("AO 2b - Combine");
+                }
+                else
+                {/*
+                    if (UsingFilterDownsample == true)
+                    {
+                        // Must use proper float precision 2.0 division to avoid artefacts
+                        cb.SetGlobalVector(PropertyID._AO_Target_TexelSize, new Vector4(1.0f / (m_target.fullWidth / 2.0f),
+                                                                                          1.0f / (m_target.fullHeight / 2.0f),
+                                                                                          m_target.fullWidth / 2.0f,
+                                                                                          m_target.fullHeight / 2.0f));
+                    }
+                    else*/
+                    {
+                        cb.SetGlobalVector(PropertyID._AO_Target_TexelSize, new Vector4(1.0f / (float)m_target.width,
+                                                                                          1.0f / (float)m_target.height,
+                                                                                          m_target.width,
+                                                                                          m_target.height));
+                    }
+
+                    //PerformBlit(cb, m_occlusionDepthRT, m_occlusionMat, occlusionPass);
+                    //Blit(cb, source, m_occlusionDepthRT, m_occlusionMat, occlusionPass);
+
+                    //cb.SetGlobalTexture(PropertyID._MainTex, source);
+                    cb.SetRenderTarget(m_occlusionDepthRT);
+                    cb.DrawMesh(m_quadMesh, Matrix4x4.identity, m_occlusionMat, 0, occlusionPass);
+
+                    //cb.SetRenderTarget(default(RenderTexture));
+                    cb.EndSample("AO 1 - ComputeOcclusion");
+
+                    if (settings.BlurEnabled == true)
+                    {
+                        commandBuffer_Blur(cb, m_occlusionDepthRT, m_target.width, m_target.height);
+                    }
+                }
+            }
+
+
+            int commandBuffer_NeighborMotionIntensity(CommandBuffer cb, int aSourceWidth, int aSourceHeight)
+            {
+                int tmpRT = AmplifyOcclusionCommon.SafeAllocateTemporaryRT(cb, "_AO_IntensityTmp_" + aSourceWidth.ToString(),
+                                                                            aSourceWidth / 2, aSourceHeight / 2,
+                                                                            m_motionIntensityRTFormat,
+                                                                            RenderTextureReadWrite.Linear,
+                                                                            FilterMode.Bilinear);
+
+
+                cb.SetGlobalVector("_AO_Target_TexelSize", new Vector4(1.0f / (aSourceWidth / 2.0f),
+                                                                         1.0f / (aSourceHeight / 2.0f),
+                                                                         aSourceWidth / 2.0f,
+                                                                         aSourceHeight / 2.0f));
+                PerformBlit(cb, tmpRT, m_occlusionMat, ShaderPass.NeighborMotionIntensity);
+
+                int tmpBlurRT = AmplifyOcclusionCommon.SafeAllocateTemporaryRT(cb, "_AO_BlurIntensityTmp",
+                                                                                aSourceWidth / 2, aSourceHeight / 2,
+                                                                                m_motionIntensityRTFormat,
+                                                                                RenderTextureReadWrite.Linear,
+                                                                                FilterMode.Bilinear);
+
+                // Horizontal
+                cb.SetGlobalTexture(PropertyID._AO_CurrMotionIntensity, tmpRT);
+                PerformBlit(cb, tmpBlurRT, m_blurMat, ShaderPass.BlurHorizontalIntensity);
+
+                // Vertical
+                cb.SetGlobalTexture(PropertyID._AO_CurrMotionIntensity, tmpBlurRT);
+                PerformBlit(cb, tmpRT, m_blurMat, ShaderPass.BlurVerticalIntensity);
+
+                AmplifyOcclusionCommon.SafeReleaseTemporaryRT(cb, tmpBlurRT);
+
+                cb.SetGlobalTexture(PropertyID._AO_CurrMotionIntensity, tmpRT);
+
+                return tmpRT;
+            }
+
+
+            void commandBuffer_Blur(CommandBuffer cb, RenderTargetIdentifier aSourceRT, int aSourceWidth, int aSourceHeight)
+            {
+                cb.BeginSample("AO 2 - Blur");
+
+                int tmpBlurRT = AmplifyOcclusionCommon.SafeAllocateTemporaryRT(cb, "_AO_BlurTmp",
+                                                                                aSourceWidth, aSourceHeight,
+                                                                                m_occlusionRTFormat,
+                                                                                RenderTextureReadWrite.Linear,
+                                                                                FilterMode.Point);
+
+                // Apply Cross Bilateral Blur
+                for (int i = 0; i < settings.BlurPasses.value; i++)
+                {
+                    // Horizontal
+                    cb.SetGlobalTexture(PropertyID._AO_CurrOcclusionDepth, aSourceRT);
+
+                    int blurHorizontalPass = ShaderPass.BlurHorizontal1 + (settings.BlurRadius.value - 1) * 2;
+
+                    PerformBlit(cb, tmpBlurRT, m_blurMat, blurHorizontalPass);
+
+
+                    // Vertical
+                    cb.SetGlobalTexture(PropertyID._AO_CurrOcclusionDepth, tmpBlurRT);
+
+                    int blurVerticalPass = ShaderPass.BlurVertical1 + (settings.BlurRadius.value - 1) * 2;
+
+                    PerformBlit(cb, aSourceRT, m_blurMat, blurVerticalPass);
+                }
+
+                AmplifyOcclusionCommon.SafeReleaseTemporaryRT(cb, tmpBlurRT);
+
+                cb.SetRenderTarget(default(RenderTexture));
+                cb.EndSample("AO 2 - Blur");
+            }
+
+
+            int getTemporalPass()
+            {
+                return ((UsingMotionVectors == true) ? (1 << 0) : 0);
+            }
+
+            /*
+                        void commandBuffer_TemporalFilter(CommandBuffer cb)
+                        {
+                            if ((m_clearHistory == true) || (m_paramsChanged == true))
+                            {
+                                clearHistory(cb);
+                            }
+
+                            // Temporal Filter
+                            float temporalAdj = Mathf.Lerp(0.01f, 0.99f, settings.FilterBlending.value);
+
+                            cb.SetGlobalFloat(PropertyID._AO_TemporalCurveAdj, temporalAdj);
+                            cb.SetGlobalFloat(PropertyID._AO_TemporalMotionSensibility, settings.FilterResponse.value * settings.FilterResponse.value + 0.01f);
+
+                            cb.SetGlobalTexture(PropertyID._AO_CurrOcclusionDepth, m_occlusionDepthRT);
+                            cb.SetGlobalTexture(PropertyID._AO_TemporalAccumm, m_temporalAccumRT[1 - m_curStepIdx]);
+                        }*/
+
+            private RenderTargetIdentifier curTemporalRT;
+
+            void commandBuffer_FillApplyPostEffect(CommandBuffer cb, RenderTargetIdentifier aSourceRT, RenderTargetIdentifier aDestinyRT, ref RenderingData renderData)
+            {
+                cb.BeginSample("AO 3 - ApplyPostEffect");
+
+
+                /*
+                                if (UsingTemporalFilter)
+                                {
+                                    commandBuffer_TemporalFilter(cb);
+
+                                    int tmpMotionIntensityRT = 0;
+
+                                    if (UsingMotionVectors == true)
+                                    {
+                                        tmpMotionIntensityRT = commandBuffer_NeighborMotionIntensity(cb, m_target.fullWidth, m_target.fullHeight);
+                                    }
+
+                                    if (UsingFilterDownsample == false)
+                                    {
+                                        applyPostEffectTargetsTemporal[0] = aDestinyRT;
+                                        applyPostEffectTargetsTemporal[1] = new RenderTargetIdentifier(m_temporalAccumRT[m_curStepIdx]);
+
+                                        cb.SetRenderTarget(applyPostEffectTargetsTemporal, applyPostEffectTargetsTemporal[0]  );// Not used, just to make Unity happy
+                                        PerformBlit(cb, m_applyOcclusionMat, ShaderPass.ApplyPostEffectTemporal + getTemporalPass());
+                                    }
+                                    else
+                                    {
+                                        // UsingFilterDownsample == true
+
+                                        RenderTargetIdentifier temporalRTid = new RenderTargetIdentifier(m_temporalAccumRT[m_curStepIdx]);
+
+                                        cb.SetRenderTarget(temporalRTid);
+                                        PerformBlit(cb, m_occlusionMat, ShaderPass.Temporal + getTemporalPass());
+
+                                        cb.SetGlobalTexture(PropertyID._AO_TemporalAccumm, temporalRTid);
+                                        cb.SetRenderTarget(aDestinyRT);
+                                        PerformBlit(cb, m_applyOcclusionMat, ShaderPass.ApplyCombineFromTemporal);
+                                    }
+
+                                    if (UsingMotionVectors == true)
+                                    {
+                                        AmplifyOcclusionCommon.SafeReleaseTemporaryRT(cb, tmpMotionIntensityRT);
+                                    }
+                                }
+                                else */
+                {
+                    cb.SetGlobalTexture(PropertyID._AO_CurrOcclusionDepth, m_occlusionDepthRT);
+
+                    cb.SetGlobalTexture(PropertyID._MainTex, aSourceRT);
+                    //m_applyOcclusionMat.SetTexture("_MainTex", aSourceRT);
+
+                    cb.SetRenderTarget(aDestinyRT);
+                    cb.DrawMesh(m_quadMesh, Matrix4x4.identity, m_applyOcclusionMat, 0, ShaderPass.ApplyPostEffect);
+                    //Blit(cb, ref renderData, m_applyOcclusionMat, ShaderPass.ApplyPostEffect);
+                    //PerformBlit(cb, aDestinyRT, m_applyOcclusionMat, ShaderPass.ApplyPostEffect);
+                }
+
+                cb.SetRenderTarget(default(RenderTexture));
+                cb.EndSample("AO 3 - ApplyPostEffect");
+            }
+
+
+            void commandBuffer_FillApplyDebug(CommandBuffer cb, RenderTargetIdentifier aSourceRT, RenderTargetIdentifier aDestinyRT)
+            {
+                cb.BeginSample("AO 3 - ApplyDebug");
+
+                cb.SetGlobalTexture(PropertyID._MainTex, aSourceRT);
+                /*
+                if (UsingTemporalFilter)
+                {
+                    commandBuffer_TemporalFilter(cb);
+
+                    int tmpMotionIntensityRT = 0;
+
+                    if (UsingMotionVectors == true)
+                    {
+                        tmpMotionIntensityRT = commandBuffer_NeighborMotionIntensity(cb, m_target.fullWidth, m_target.fullHeight);
+                    }
+
+                    if (UsingFilterDownsample == false)
+                    {
+                        applyDebugTargetsTemporal[0] = aDestinyRT;
+                        applyDebugTargetsTemporal[1] = new RenderTargetIdentifier(m_temporalAccumRT[m_curStepIdx]);
+
+                        cb.SetRenderTarget(applyDebugTargetsTemporal, applyDebugTargetsTemporal[0]  );// Not used, just to make Unity happy
+                        PerformBlit(cb, m_applyOcclusionMat, ShaderPass.ApplyDebugTemporal + getTemporalPass());
+                    }
+                    else
+                    {
+                        // UsingFilterDownsample == true
+
+                        RenderTargetIdentifier temporalRTid = new RenderTargetIdentifier(m_temporalAccumRT[m_curStepIdx]);
+
+                        cb.SetRenderTarget(temporalRTid);
+                        PerformBlit(cb, m_occlusionMat, ShaderPass.Temporal + getTemporalPass());
+
+                        cb.SetGlobalTexture(PropertyID._AO_TemporalAccumm, temporalRTid);
+                        cb.SetRenderTarget(aDestinyRT);
+                        PerformBlit(cb, m_applyOcclusionMat, ShaderPass.ApplyDebugCombineFromTemporal);
+                    }
+
+                    if (UsingMotionVectors == true)
+                    {
+                        AmplifyOcclusionCommon.SafeReleaseTemporaryRT(cb, tmpMotionIntensityRT);
+                    }
+                }
+                else*/
+                {
+                    cb.SetGlobalTexture(PropertyID._AO_CurrOcclusionDepth, m_occlusionDepthRT);
+                    PerformBlit(cb, aDestinyRT, m_applyOcclusionMat, ShaderPass.ApplyDebug);
+                }
+
+                cb.SetRenderTarget(default(RenderTexture));
+                cb.EndSample("AO 3 - ApplyDebug");
+            }
+
+            private void clearHistory(CommandBuffer cb)
+            {
+                m_clearHistory = false;
+
+                if ((m_temporalAccumRT != null) && (m_occlusionDepthRT != null))
+                {
+                    cb.SetGlobalTexture(PropertyID._AO_CurrOcclusionDepth, m_occlusionDepthRT);
+                    cb.SetRenderTarget(m_temporalAccumRT[0]);
+                    PerformBlit(cb, m_occlusionMat, ShaderPass.ClearTemporal);
+
+                    cb.SetGlobalTexture(PropertyID._AO_CurrOcclusionDepth, m_occlusionDepthRT);
+                    cb.SetRenderTarget(m_temporalAccumRT[1]);
+                    PerformBlit(cb, m_occlusionMat, ShaderPass.ClearTemporal);
+                }
+            }
+
+            private void checkParamsChanged(Camera aCamera)
+            {
+                bool HDR = aCamera.allowHDR; // && tier?
+                bool MSAA = aCamera.allowMSAA &&
+                            QualitySettings.antiAliasing >= 1;
+
+                int antiAliasing = MSAA ? QualitySettings.antiAliasing : 1;
+                //int antiAliasing = 1;
+
+                if (m_occlusionDepthRT != null)
+                {
+                    if ((m_occlusionDepthRT.width != m_target.width) ||
+                        (m_occlusionDepthRT.height != m_target.height) ||
+                        (m_prevMSAA != MSAA) ||
+                        //(m_prevFilterEnabled != UsingTemporalFilter) ||
+                        //(m_prevFilterDownsample != UsingFilterDownsample) ||
+                        (!m_occlusionDepthRT.IsCreated()) ||
+                        (m_temporalAccumRT != null && (!m_temporalAccumRT[0].IsCreated() || !m_temporalAccumRT[1].IsCreated()))
+                        )
+                    {
+                        AmplifyOcclusionCommon.SafeReleaseRT(ref m_occlusionDepthRT);
+                        AmplifyOcclusionCommon.SafeReleaseRT(ref m_depthMipmap);
+                        releaseTemporalRT();
+
+                        m_paramsChanged = true;
+                    }
+                }
+
+                if (m_temporalAccumRT != null)
+                {
+                    if (m_temporalAccumRT.Length != 2)
+                    {
+                        m_temporalAccumRT = null;
+                    }
+                }
+
+                if (m_occlusionDepthRT == null)
+                {
+                    m_occlusionDepthRT = AmplifyOcclusionCommon.SafeAllocateRT("_AO_OcclusionDepthTexture",
+                                                                                m_target.width,
+                                                                                m_target.height,
+                                                                                m_occlusionRTFormat,
+                                                                                RenderTextureReadWrite.Linear,
+                                                                                FilterMode.Bilinear);
+                }
+
+
+                if (m_temporalAccumRT == null) // UsingTemporalFilter
+                {
+                    m_temporalAccumRT = new RenderTexture[2];
+
+                    m_temporalAccumRT[0] = AmplifyOcclusionCommon.SafeAllocateRT("_AO_TemporalAccum_0",
+                                                                                    m_target.width,
+                                                                                    m_target.height,
+                                                                                    m_accumTemporalRTFormat,
+                                                                                    RenderTextureReadWrite.Linear,
+                                                                                    FilterMode.Bilinear,
+                                                                                    antiAliasing);
+
+                    m_temporalAccumRT[1] = AmplifyOcclusionCommon.SafeAllocateRT("_AO_TemporalAccum_1",
+                                                                                    m_target.width,
+                                                                                    m_target.height,
+                                                                                    m_accumTemporalRTFormat,
+                                                                                    RenderTextureReadWrite.Linear,
+                                                                                    FilterMode.Bilinear,
+                                                                                    antiAliasing);
+
+                    m_clearHistory = true;
+                }
+
+                if ((settings.CacheAware == true) && (m_depthMipmap == null))
+                {
+                    m_depthMipmap = AmplifyOcclusionCommon.SafeAllocateRT("_AO_DepthMipmap",
+                                                                            m_target.fullWidth >> 1,
+                                                                            m_target.fullHeight >> 1,
+                                                                            RenderTextureFormat.RFloat,
+                                                                            RenderTextureReadWrite.Linear,
+                                                                            FilterMode.Point,
+                                                                            1,
+                                                                            true);
+
+                    int minSize = (int)Mathf.Min(m_target.fullWidth, m_target.fullHeight);
+                    m_numberMips = (int)(Mathf.Log((float)minSize, 2.0f) + 1.0f) - 1;
+
+                    m_tmpMipString = null;
+                    m_tmpMipString = new string[m_numberMips];
+
+                    for (int i = 0; i < m_numberMips; i++)
+                    {
+                        m_tmpMipString[i] = "_AO_TmpMip_" + i.ToString();
+                    }
+                }
+                else
+                {
+                    if ((settings.CacheAware == false) && (m_depthMipmap != null))
+                    {
+                        AmplifyOcclusionCommon.SafeReleaseRT(ref m_depthMipmap);
+                        m_tmpMipString = null;
+                    }
+                }
+
+                if ((m_prevSampleCount != settings.SampleCount.value) ||
+                    (m_prevDownsample != settings.Downsample.value) ||
+                    (m_prevCacheAware != settings.CacheAware.value) ||
+                    (m_prevBlurEnabled != settings.BlurEnabled.value) ||
+                    (m_prevBlurPasses != settings.BlurPasses.value) ||
+                    (m_prevBlurRadius != settings.BlurRadius.value) ||
+                    //(m_prevFilterEnabled != UsingTemporalFilter) ||
+                    //(m_prevFilterDownsample != UsingFilterDownsample) ||
+                    (m_prevHDR != HDR) ||
+                    (m_prevMSAA != MSAA))
+                {
+                    m_clearHistory |= (m_prevHDR != HDR);
+                    m_clearHistory |= (m_prevMSAA != MSAA);
+
+                    m_HDR = HDR;
+                    m_MSAA = MSAA;
+
+                    m_paramsChanged = true;
+                }
+            }
+
+
+            private void updateParams()
+            {
+                m_prevSampleCount = settings.SampleCount.value;
+                m_prevDownsample = settings.Downsample.value;
+                m_prevCacheAware = settings.CacheAware.value;
+                m_prevBlurEnabled = settings.BlurEnabled.value;
+                m_prevBlurPasses = settings.BlurPasses.value;
+                m_prevBlurRadius = settings.BlurRadius.value;
+                //m_prevFilterEnabled = UsingTemporalFilter;
+                //m_prevFilterDownsample = UsingFilterDownsample;
+                m_prevHDR = m_HDR;
+                m_prevMSAA = m_MSAA;
+
+                m_paramsChanged = false;
+            }
+
+
+            public DepthTextureMode GetCameraFlags()
+            {
+                return DepthTextureMode.Depth | DepthTextureMode.MotionVectors;
+            }
+
+            private void releaseTemporalRT()
+            {
+                if (m_temporalAccumRT != null)
+                {
+                    if (m_temporalAccumRT.Length != 0)
+                    {
+                        AmplifyOcclusionCommon.SafeReleaseRT(ref m_temporalAccumRT[0]);
+                        AmplifyOcclusionCommon.SafeReleaseRT(ref m_temporalAccumRT[1]);
+                    }
+                }
+
+                m_temporalAccumRT = null;
+            }
+        }
+    }
+}

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Plugins/SRP/AmplifyOcclusionRenderer.cs.meta
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Plugins/SRP/AmplifyOcclusionRenderer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1778b560afb13c5449aadc62983479fb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Plugins/SRP/AmplifyOcclusionVolume.cs
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Plugins/SRP/AmplifyOcclusionVolume.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.Universal;
+
+namespace AmplifyOcclusion
+{
+    [VolumeComponentMenu("Amplify Creations/Amplify Occlusion V2")]
+    public class AmplifyOcclusionVolume : VolumeComponent, IPostProcessComponent
+    {
+        public enum ApplicationMethod
+        {
+            PostEffect = 0,
+            Debug
+        }
+        public enum PerPixelNormalSource
+        {
+            None = 0,
+            GBuffer
+        }
+
+        [Serializable] public class ApplicationMethodParameter : VolumeParameter<ApplicationMethod> { }
+        [Serializable] public class SampleCountLevelVolumeParameter : VolumeParameter<SampleCountLevel> { }
+        //[Serializable] public class PerPixelNormalSourceVolumeParameter : VolumeParameter<PerPixelNormalSource> {}
+
+
+        //[Tooltip("Enable Amplify Occlusion.")]
+        //public BoolParameter enabled = new BoolParameter(true, true);
+
+        [Header("Ambient Occlusion")]
+        [Tooltip("How to inject the occlusion: Post Effect = Overlay, Debug - Vizualize.")]
+        public ApplicationMethodParameter ApplyMethod = new ApplicationMethodParameter { value = ApplicationMethod.PostEffect, overrideState = true };
+
+        [Tooltip("Number of samples per pass.")]
+        public SampleCountLevelVolumeParameter SampleCount = new SampleCountLevelVolumeParameter { value = SampleCountLevel.Medium, overrideState = true };
+        public NoInterpTextureParameter RampTexture = new NoInterpTextureParameter(null);
+        //[Tooltip("Source of per-pixel normals: None = All, GBuffer = Deferred.")]
+        //public PerPixelNormalSourceVolumeParameter PerPixelNormals = new PerPixelNormalSourceVolumeParameter { value = PerPixelNormalSource.None };
+
+        [Tooltip("Final applied intensity of the occlusion effect.")]
+        public ClampedFloatParameter Intensity = new ClampedFloatParameter(1.0f, 0, 1, true);
+
+        [Tooltip("Color tint for occlusion.")]
+        public ColorParameter Tint = new ColorParameter(Color.black);
+
+        [Tooltip("Radius spread of the occlusion.")]
+        public ClampedFloatParameter Radius = new ClampedFloatParameter(2.0f, 0, 32, true);
+
+        [Tooltip("Power exponent attenuation of the occlusion.")]
+        public ClampedFloatParameter PowerExponent = new ClampedFloatParameter(1.8f, 0, 16, true);
+
+        [Tooltip("Controls the initial occlusion contribution offset.")]
+        public ClampedFloatParameter Bias = new ClampedFloatParameter(0.05f, 0, 0.99f);
+
+        [Tooltip("Controls the thickness occlusion contribution.")]
+        public ClampedFloatParameter Thickness = new ClampedFloatParameter(1.0f, 0, 1.0f, true);
+
+        [Tooltip("Compute the Occlusion and Blur at half of the resolution.")]
+        public BoolParameter Downsample = new BoolParameter(true, true);
+
+        [Tooltip("Cache optimization for best performance / quality tradeoff.")]
+        public BoolParameter CacheAware = new BoolParameter(false);
+
+        [Header("Distance Fade")]
+        [Tooltip("Control parameters at faraway.")]
+        public BoolParameter FadeEnabled = new BoolParameter(false);
+
+        [Tooltip("Distance in Unity unities that start to fade.")]
+        public FloatParameter FadeStart = new FloatParameter(100.0f);
+
+        [Tooltip("Length distance to performe the transition.")]
+        public FloatParameter FadeLength = new FloatParameter(50.0f);
+
+        [Tooltip("Final Intensity parameter.")]
+        public ClampedFloatParameter FadeToIntensity = new ClampedFloatParameter(0.0f, 0, 1);
+        public ColorParameter FadeToTint = new ColorParameter(Color.black);
+
+        [Tooltip("Final Radius parameter.")]
+        public ClampedFloatParameter FadeToRadius = new ClampedFloatParameter(2.0f, 0, 32);
+
+        [Tooltip("Final PowerExponent parameter.")]
+        public ClampedFloatParameter FadeToPowerExponent = new ClampedFloatParameter(1.0f, 0, 16);
+
+        [Tooltip("Final Thickness parameter.")]
+        public ClampedFloatParameter FadeToThickness = new ClampedFloatParameter(1.0f, 0, 1.0f);
+
+        [Header("Bilateral Blur")]
+        public BoolParameter BlurEnabled = new BoolParameter(true, true);
+
+        [Tooltip("Radius in screen pixels.")]
+        public ClampedIntParameter BlurRadius = new ClampedIntParameter(3, 1, 4, true);
+
+        [Tooltip("Number of times that the Blur will repeat.")]
+        public ClampedIntParameter BlurPasses = new ClampedIntParameter(1, 1, 4, true);
+
+        [Tooltip("Sharpness of blur edge-detection: 0 = Softer Edges, 20 = Sharper Edges.")]
+        public ClampedFloatParameter BlurSharpness = new ClampedFloatParameter(15.0f, 0, 20, true);
+/*
+        [Header("Temporal Filter")]
+        [Tooltip("Accumulates the effect over the time.")]
+        public BoolParameter FilterEnabled = new BoolParameter(true, true);
+        public BoolParameter FilterDownsample = new BoolParameter(true, true);
+
+        [Tooltip("Controls the accumulation decayment: 0 = More flicker with less ghosting, 1 = Less flicker with more ghosting.")]
+        public ClampedFloatParameter FilterBlending = new ClampedFloatParameter(0.80f, 0, 1, true);
+
+        [Tooltip("Controls the discard sensitivity based on the motion of the scene and objects.")]
+        public ClampedFloatParameter FilterResponse = new ClampedFloatParameter(0.5f, 0, 1, true);
+*/
+        public bool IsActive() => true;
+        public bool IsTileCompatible() => true;
+
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+            displayName = "Amplify Occlusion";
+        }
+    }
+}

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Plugins/SRP/AmplifyOcclusionVolume.cs.meta
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Plugins/SRP/AmplifyOcclusionVolume.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9a1a0912ccc82aa49bc9c20a5f3409b2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources.meta
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: b93186d740e83604b9c1a073b45f4059
+folderAsset: yes
+timeCreated: 1449343868
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/Apply.shader
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/Apply.shader
@@ -1,0 +1,430 @@
+// Amplify Occlusion 2 - Robust Ambient Occlusion for Unity
+// Copyright (c) Amplify Creations, Lda <info@amplify.pt>
+
+Shader "Hidden/Amplify Occlusion/Apply"
+{
+	CGINCLUDE
+		#pragma vertex vert
+		#pragma fragment frag
+		#pragma target 3.0
+		#pragma exclude_renderers gles d3d11_9x n3ds
+		#pragma multi_compile_instancing
+
+		#include "Common.cginc"
+		#include "TemporalFilter.cginc"
+
+		UNITY_DECLARE_SCREENSPACE_TEXTURE( _AO_GBufferAlbedo );
+		UNITY_DECLARE_SCREENSPACE_TEXTURE( _AO_GBufferEmission );
+		UNITY_DECLARE_SCREENSPACE_TEXTURE( _AO_ApplyOcclusionTexture );
+
+
+		struct DeferredOutput
+		{
+			half4 albedo : SV_Target0;
+			half4 emission : SV_Target1;
+		};
+
+		struct DeferredOutputTemporal
+		{
+			half4 albedo : SV_Target0;
+			half4 emission : SV_Target1;
+			half4 temporalAcc : SV_Target2;
+		};
+
+
+		#include "ApplyPostEffect.cginc"
+
+
+		PostEffectOutputTemporal ApplyPostEffectTemporal( v2f_in IN, const bool aUseMotionVectors )
+		{
+			UNITY_SETUP_INSTANCE_ID( IN );
+			UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX( IN );
+
+			const float2 screenPos = IN.uv.xy;
+
+			const half2 occlusionDepth = FetchOcclusionDepth( screenPos );
+
+			PostEffectOutputTemporal OUT;
+
+			if( occlusionDepth.y < HALF_MAX )
+			{
+				const half linear01Depth = occlusionDepth.y * ONE_OVER_DEPTH_SCALE;
+				const half sampledDepth = Linear01ToSampledDepth( linear01Depth );
+				const half linearEyeDepth = occlusionDepth.y * _AO_BufDepthToLinearEye;
+
+				half occlusion;
+				const half4 temporalAcc = TemporalFilter( screenPos, occlusionDepth.x, sampledDepth, linearEyeDepth, linear01Depth, aUseMotionVectors, occlusion );
+
+				const half4 occlusionRGBA = CalcOcclusion( occlusion, linearEyeDepth );
+
+				OUT.occlusionColor = occlusionRGBA;
+				OUT.temporalAcc = temporalAcc;
+			}
+			else
+			{
+				OUT.occlusionColor = half4( (1).xxxx );
+				OUT.temporalAcc = half4( (1).xxxx );
+			}
+
+			return OUT;
+		}
+
+
+		half4 ApplyPostEffect( v2f_in IN )
+		{
+			UNITY_SETUP_INSTANCE_ID( IN );
+			UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX( IN );
+
+			const half2 screenPos = IN.uv.xy;
+
+			const half2 occlusionDepth = FetchOcclusionDepth( screenPos );
+
+			const half linearEyeDepth = occlusionDepth.y * _AO_BufDepthToLinearEye;
+
+			const half4 occlusionRGBA = CalcOcclusion( occlusionDepth.x, linearEyeDepth );
+
+			return half4( occlusionRGBA.rgb, 1 );
+		}
+
+
+		DeferredOutput ApplyDeferred( v2f_in IN, const bool log )
+		{
+			UNITY_SETUP_INSTANCE_ID( IN );
+			UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX( IN );
+
+			const half2 screenPos = IN.uv.xy;
+
+			const half2 occlusionDepth = FetchOcclusionDepth( screenPos );
+
+			const half linearEyeDepth = occlusionDepth.y * _AO_BufDepthToLinearEye;
+
+			const half4 occlusionRGBA = CalcOcclusion( occlusionDepth.x, linearEyeDepth );
+
+			half4 emission, albedo;
+
+			if ( log )
+			{
+				emission = UNITY_SAMPLE_SCREENSPACE_TEXTURE( _AO_GBufferEmission, UnityStereoTransformScreenSpaceTex( screenPos ) );
+				albedo = UNITY_SAMPLE_SCREENSPACE_TEXTURE( _AO_GBufferAlbedo, UnityStereoTransformScreenSpaceTex( screenPos ) );
+
+				emission.rgb = -log2( emission.rgb );
+				emission.rgb *= occlusionRGBA.rgb;
+
+				albedo.a *= occlusionRGBA.a;
+
+				emission.rgb = exp2( -emission.rgb );
+			}
+			else
+			{
+				albedo = half4( 1, 1, 1, occlusionRGBA.a );
+				emission = half4( occlusionRGBA.rgb, 1 );
+			}
+
+			DeferredOutput OUT;
+			OUT.albedo = albedo;
+			OUT.emission = emission;
+			return OUT;
+		}
+
+
+		DeferredOutput ApplyDeferredCombineFromTemporal( v2f_in IN, const bool log )
+		{
+			UNITY_SETUP_INSTANCE_ID( IN );
+			UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX( IN );
+
+			const half2 screenPos = IN.uv.xy;
+
+			const half depthSample = SampleDepth0( screenPos );
+
+			const half2 occlusionLinearEyeDepth = ComputeCombineDownsampledOcclusionFromTemporal( screenPos, depthSample );
+
+			const half4 occlusionRGBA = CalcOcclusion( occlusionLinearEyeDepth.x, occlusionLinearEyeDepth.y );
+
+			half4 emission, albedo;
+
+			if ( log )
+			{
+				emission = UNITY_SAMPLE_SCREENSPACE_TEXTURE( _AO_GBufferEmission, UnityStereoTransformScreenSpaceTex( screenPos ) );
+				albedo = UNITY_SAMPLE_SCREENSPACE_TEXTURE( _AO_GBufferAlbedo, UnityStereoTransformScreenSpaceTex( screenPos ) );
+
+				emission.rgb = -log2( emission.rgb );
+				emission.rgb *= occlusionRGBA.rgb;
+
+				albedo.a *= occlusionRGBA.a;
+
+				emission.rgb = exp2( -emission.rgb );
+			}
+			else
+			{
+				albedo = half4( 1, 1, 1, occlusionRGBA.a );
+				emission = half4( occlusionRGBA.rgb, 1 );
+			}
+
+			DeferredOutput OUT;
+			OUT.albedo = albedo;
+			OUT.emission = emission;
+			return OUT;
+		}
+
+
+		DeferredOutputTemporal ApplyDeferredTemporal( v2f_in IN, const bool log, const bool aUseMotionVectors )
+		{
+			UNITY_SETUP_INSTANCE_ID( IN );
+			UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX( IN );
+
+			const float2 screenPos = IN.uv.xy;
+
+			const half2 occlusionDepth = FetchOcclusionDepth( screenPos );
+
+			DeferredOutputTemporal OUT;
+
+			if( occlusionDepth.y < HALF_MAX )
+			{
+				const half linear01Depth = occlusionDepth.y * ONE_OVER_DEPTH_SCALE;
+				const half sampledDepth = Linear01ToSampledDepth( linear01Depth );
+				const half linearEyeDepth = occlusionDepth.y * _AO_BufDepthToLinearEye;
+
+				half occlusion;
+				const half4 temporalAcc = TemporalFilter( screenPos, occlusionDepth.x, sampledDepth, linearEyeDepth, linear01Depth, aUseMotionVectors, occlusion );
+
+				const half4 occlusionRGBA = CalcOcclusion( occlusion, linearEyeDepth );
+
+				half4 emission, albedo;
+
+				if ( log )
+				{
+					emission = UNITY_SAMPLE_SCREENSPACE_TEXTURE( _AO_GBufferEmission, UnityStereoTransformScreenSpaceTex( screenPos ) );
+					albedo = UNITY_SAMPLE_SCREENSPACE_TEXTURE( _AO_GBufferAlbedo, UnityStereoTransformScreenSpaceTex( screenPos ) );
+
+					emission.rgb = -log2( emission.rgb );
+					emission.rgb *= occlusionRGBA.rgb;
+
+					albedo.a *= occlusionRGBA.a;
+
+					emission.rgb = exp2( -emission.rgb );
+				}
+				else
+				{
+					albedo = half4( 1, 1, 1, occlusionRGBA.a );
+					emission = half4( occlusionRGBA.rgb, 1 );
+				}
+
+				OUT.albedo = albedo;
+				OUT.emission = emission;
+				OUT.temporalAcc = temporalAcc;
+			}
+			else
+			{
+				half4 emission, albedo;
+
+				if ( log )
+				{
+					emission = UNITY_SAMPLE_SCREENSPACE_TEXTURE( _AO_GBufferEmission, UnityStereoTransformScreenSpaceTex( screenPos ) );
+					albedo = UNITY_SAMPLE_SCREENSPACE_TEXTURE( _AO_GBufferAlbedo, UnityStereoTransformScreenSpaceTex( screenPos ) );
+				}
+				else
+				{
+					albedo = half4( (1).xxxx );
+					emission = half4( (1).xxxx );
+				}
+
+				OUT.albedo = albedo;
+				OUT.emission = emission;
+				OUT.temporalAcc = half4( (1).xxxx );
+			}
+
+			return OUT;
+		}
+
+
+		half4 ApplyPostEffectTemporalMultiply( v2f_in IN )
+		{
+			UNITY_SETUP_INSTANCE_ID( IN );
+			UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX( IN );
+
+			return UNITY_SAMPLE_SCREENSPACE_TEXTURE( _AO_ApplyOcclusionTexture, UnityStereoTransformScreenSpaceTex( IN.uv.xy ) );
+		}
+
+		DeferredOutput ApplyDeferredTemporalMultiply( v2f_in IN )
+		{
+			UNITY_SETUP_INSTANCE_ID( IN );
+			UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX( IN );
+
+			const half4 occlusionRGBA = UNITY_SAMPLE_SCREENSPACE_TEXTURE( _AO_ApplyOcclusionTexture, UnityStereoTransformScreenSpaceTex( IN.uv.xy ) );
+
+			DeferredOutput OUT;
+			OUT.albedo = half4( (1.0).xxx, occlusionRGBA.a );
+			OUT.emission = half4( occlusionRGBA.rgb, 1.0 );
+
+			return OUT;
+		}
+
+	ENDCG
+
+	///////////////////////////////////////////////////////////////////////////////////////
+	// MRT BLENDING PATH
+	///////////////////////////////////////////////////////////////////////////////////////
+
+	SubShader
+	{
+		Tags { "MRTBlending" = "True" }
+		ZTest Always Cull Off ZWrite Off
+
+		// -- APPLICATION METHODS --------------------------------------------------------------
+		// 0 => APPLY DEBUG
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return ApplyDebug( IN ); } ENDCG }
+		// 1 => APPLY DEBUG Temporal
+		Pass { CGPROGRAM PostEffectOutputTemporal frag( v2f_in IN ) { return ApplyDebugTemporal( IN, false); } ENDCG }
+		Pass { CGPROGRAM PostEffectOutputTemporal frag( v2f_in IN ) { return ApplyDebugTemporal( IN, true ); } ENDCG }
+
+		// 3 => APPLY DEFERRED
+		Pass
+		{
+			Blend DstColor Zero, DstAlpha Zero
+			CGPROGRAM DeferredOutput frag( v2f_in IN ) { return ApplyDeferred( IN, false ); } ENDCG
+		}
+		// 4 => APPLY DEFERRED Temporal
+		Pass
+		{
+			Blend 0 DstColor Zero, DstAlpha Zero
+			Blend 1 DstColor Zero, DstAlpha Zero
+			Blend 2 Off
+			CGPROGRAM DeferredOutputTemporal frag( v2f_in IN ) { return ApplyDeferredTemporal( IN, false, false ); } ENDCG
+		}
+		Pass
+		{
+			Blend 0 DstColor Zero, DstAlpha Zero
+			Blend 1 DstColor Zero, DstAlpha Zero
+			Blend 2 Off
+			CGPROGRAM DeferredOutputTemporal frag( v2f_in IN ) { return ApplyDeferredTemporal( IN, false, true ); } ENDCG
+		}
+
+		// 6 => APPLY DEFERRED (LOG)
+		Pass { CGPROGRAM DeferredOutput frag( v2f_in IN ) { return ApplyDeferred( IN, true ); } ENDCG }
+		// 7 => APPLY DEFERRED (LOG) Temporal
+		Pass { CGPROGRAM DeferredOutputTemporal frag( v2f_in IN ) { return ApplyDeferredTemporal( IN, true, false ); } ENDCG }
+		Pass { CGPROGRAM DeferredOutputTemporal frag( v2f_in IN ) { return ApplyDeferredTemporal( IN, true, true ); } ENDCG }
+
+
+		// 9 => APPLY POST-EFFECT
+		Pass
+		{
+			Blend DstColor Zero
+			CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return ApplyPostEffect( IN ); } ENDCG
+		}
+		// 10 => APPLY POST-EFFECT Temporal
+		Pass
+		{
+			Blend 0 DstColor Zero
+			Blend 1 Off
+			CGPROGRAM PostEffectOutputTemporal frag( v2f_in IN ) { return ApplyPostEffectTemporal( IN, false ); } ENDCG
+		}
+		Pass
+		{
+			Blend 0 DstColor Zero
+			Blend 1 Off
+			CGPROGRAM PostEffectOutputTemporal frag( v2f_in IN ) { return ApplyPostEffectTemporal( IN, true ); } ENDCG
+		}
+
+		// 12 => dummy
+		Pass { }
+
+		// 13 => dummy
+		Pass { }
+
+		// 14 => APPLY DEBUG Combine from Temporal
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return ApplyDebugCombineFromTemporal( IN ); } ENDCG }
+
+		// 15 => APPLY POST-EFFECT Combine from Temporal
+		Pass
+		{
+			Blend DstColor Zero
+			CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return ApplyCombineFromTemporal( IN ); } ENDCG
+		}
+
+		// 16 => APPLY DEFERRED Combine from Temporal
+		Pass
+		{
+			Blend DstColor Zero, DstAlpha Zero
+			CGPROGRAM DeferredOutput frag( v2f_in IN ) { return ApplyDeferredCombineFromTemporal( IN, false ); } ENDCG
+		}
+
+		// 17 => APPLY DEFERRED (LOG) Combine from Temporal
+		Pass { CGPROGRAM DeferredOutput frag( v2f_in IN ) { return ApplyDeferredCombineFromTemporal( IN, true ); } ENDCG }
+	}
+
+	///////////////////////////////////////////////////////////////////////////////////////
+	// NO MRT BLENDING FALLBACK
+	///////////////////////////////////////////////////////////////////////////////////////
+
+	SubShader
+	{
+		Tags { "MRTBlending" = "False" }
+		ZTest Always Cull Off ZWrite Off
+
+		// -- APPLICATION METHODS --------------------------------------------------------------
+		// 0 => APPLY DEBUG
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return ApplyDebug( IN ); } ENDCG }
+		// 1 => APPLY DEBUG Temporal
+		Pass { CGPROGRAM PostEffectOutputTemporal frag( v2f_in IN ) { return ApplyDebugTemporal( IN, false ); } ENDCG }
+		Pass { CGPROGRAM PostEffectOutputTemporal frag( v2f_in IN ) { return ApplyDebugTemporal( IN, true ); } ENDCG }
+
+		// 3 => APPLY DEFERRED
+		Pass
+		{
+			Blend DstColor Zero, DstAlpha Zero
+			CGPROGRAM DeferredOutput frag( v2f_in IN ) { return ApplyDeferred( IN, false ); } ENDCG
+		}
+		// 4 => APPLY DEFERRED Temporal
+		Pass { CGPROGRAM DeferredOutputTemporal frag( v2f_in IN ) { return ApplyDeferredTemporal( IN, false, false ); } ENDCG }
+		Pass { CGPROGRAM DeferredOutputTemporal frag( v2f_in IN ) { return ApplyDeferredTemporal( IN, false, true ); } ENDCG }
+
+		// 6 => APPLY DEFERRED (LOG)
+		Pass { CGPROGRAM DeferredOutput frag( v2f_in IN ) { return ApplyDeferred( IN, true ); } ENDCG }
+		// 7 => APPLY DEFERRED (LOG) Temporal
+		Pass { CGPROGRAM DeferredOutputTemporal frag( v2f_in IN ) { return ApplyDeferredTemporal( IN, true, false ); } ENDCG }
+		Pass { CGPROGRAM DeferredOutputTemporal frag( v2f_in IN ) { return ApplyDeferredTemporal( IN, true, true ); } ENDCG }
+
+		// 9 => APPLY POST-EFFECT
+		Pass { Blend DstColor Zero CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return ApplyPostEffect( IN ); } ENDCG }
+		// 10 => APPLY POST-EFFECT Temporal
+		Pass { CGPROGRAM PostEffectOutputTemporal frag( v2f_in IN ) { return ApplyPostEffectTemporal( IN, false ); } ENDCG }
+		Pass { CGPROGRAM PostEffectOutputTemporal frag( v2f_in IN ) { return ApplyPostEffectTemporal( IN, true ); } ENDCG }
+
+		// 12 => APPLY POST-EFFECT Temporal Multiply
+		Pass
+		{
+			Blend DstColor Zero
+			CGPROGRAM half4 frag( v2f_in IN ) : SV_Target0 { return ApplyPostEffectTemporalMultiply( IN ); } ENDCG
+		}
+
+		// 13 => APPLY DEFERRED Temporal Multiply
+		Pass
+		{
+			Blend DstColor Zero, DstAlpha Zero
+			CGPROGRAM DeferredOutput frag( v2f_in IN ) { return ApplyDeferredTemporalMultiply( IN ); } ENDCG
+		}
+
+		// 14 => APPLY DEBUG Combine from Temporal
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return ApplyDebugCombineFromTemporal( IN ); } ENDCG }
+
+		// 15 => APPLY POST-EFFECT Combine from Temporal
+		Pass
+		{
+			Blend DstColor Zero
+			CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return ApplyCombineFromTemporal( IN ); } ENDCG
+		}
+
+		// 16 => APPLY DEFERRED Combine from Temporal
+		Pass
+		{
+			Blend DstColor Zero, DstAlpha Zero
+			CGPROGRAM DeferredOutput frag( v2f_in IN ) { return ApplyDeferredCombineFromTemporal( IN, false ); } ENDCG
+		}
+
+		// 17 => APPLY DEFERRED (LOG) Combine from Temporal
+		Pass { CGPROGRAM DeferredOutput frag( v2f_in IN ) { return ApplyDeferredCombineFromTemporal( IN, true ); } ENDCG }
+	}
+
+	Fallback Off
+}

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/Apply.shader.meta
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/Apply.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 537ee96eb0f0e5348bead799d732fa65
+timeCreated: 1451519501
+licenseType: Pro
+ShaderImporter:
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/ApplyPostEffect.cginc
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/ApplyPostEffect.cginc
@@ -1,0 +1,144 @@
+// Amplify Occlusion 2 - Robust Ambient Occlusion for Unity
+// Copyright (c) Amplify Creations, Lda <info@amplify.pt>
+
+#ifndef AMPLIFY_AO_APPLY_POSTEFFECT
+#define AMPLIFY_AO_APPLY_POSTEFFECT
+
+struct PostEffectOutputTemporal
+{
+	half4 occlusionColor : SV_Target0;
+	half4 temporalAcc : SV_Target1;
+};
+
+inline half4 _CalcOcclusionColor( const half aOcclusion )
+{
+	const half distanceFade = saturate(_AO_FadeParams.x * _AO_FadeParams.y);
+	const half exponent = lerp( _AO_PowExponent, _AO_FadeValues.z, distanceFade );
+	//const half occlusion = pow( max( aOcclusion, 0.0 ), exponent );
+	half3 tintedOcclusion = lerp( _AO_Levels.rgb, _AO_FadeToTint.rgb, distanceFade );
+	//tintedOcclusion = lerp( tintedOcclusion, ( 1 ).xxx, aOcclusion.xxx );
+	//const half intensity = lerp( _AO_Levels.a, _AO_FadeValues.x, distanceFade );
+	return half4( tintedOcclusion.rgb, aOcclusion );
+	//return lerp( 0, half4( tintedOcclusion.rgb, occlusion ), intensity );
+}
+sampler2D _OcclusionRamp;
+half4 _ApplyPostEffect( v2f_in IN, half4 srcColor )
+{
+	half2 screenPos = IN.uv.xy;
+	//const half linearEyeDepth = occlusionDepth.y * _AO_BufDepthToLinearEye;
+	half2 occlusionPacked = FetchOcclusionDepth( screenPos );
+	half occlusion = occlusionPacked.r;
+	occlusion = occlusion;
+	const half distanceFade = saturate(_AO_FadeParams.x * _AO_FadeParams.y);
+	const half exponent = lerp( _AO_PowExponent, _AO_FadeValues.z, distanceFade );
+	
+	half occ = occlusion;
+	occ =  pow( max( occ, 0.0 ), exponent );
+	//occ = smoothstep(occ - exponent, occ + exponent, exponent);
+	half4 occlusionRGBA = _CalcOcclusionColor( occ );
+	occ = occlusionRGBA.a;
+	half3 ramp = tex2D(_OcclusionRamp, half2(clamp(occ, 0.01, 0.99), 0)).rgb;
+	
+	// could we use mipmaps to mimic blur for cheap and dirty color bleed?
+	//half2 uv =  UnityStereoTransformScreenSpaceTex( screenPos ) ;
+	//float2 uv_dx = clamp( ddx( uv ), minval, maxval );
+	//float2 uv_dy = clamp( ddy( uv ), minval, maxval );
+	//half4 texsample = tex2D( _MainTex, uv, uv_dx, uv_dy );
+	
+	//const half4 srcColor = tex2D( _MainTex, uv);
+	occlusionRGBA.rgb *= ramp;
+	
+	//half4 outColor = half4( srcColor.rgb * lerp( (1).xxx, (srcColor + occlusionRGBA.rgb), srcColor.a), srcColor.a );
+	return half4(lerp(srcColor.rgb, (srcColor.rgb * _AO_Levels.rgb * ramp.rgb), 1 - ramp), srcColor.a);
+	//return lerp(srcColor, outColor, _AO_Levels.a);
+}
+
+half4 ApplyDebug( const v2f_in IN )
+{
+	UNITY_SETUP_INSTANCE_ID( IN );
+	UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX( IN );
+/*
+	const half2 screenPos = IN.uv.xy;
+
+	const half2 occlusionDepth = FetchOcclusionDepth( screenPos );
+
+	const half linearEyeDepth = occlusionDepth.y * _AO_BufDepthToLinearEye;
+
+	const half4 occlusionRGBA = CalcOcclusion( occlusionDepth.x, linearEyeDepth );
+
+	return half4( occlusionRGBA.rgb, 1 );*/
+
+	return _ApplyPostEffect(IN, 1);
+}
+
+
+half4 ApplyDebugCombineFromTemporal( const v2f_in IN )
+{
+	UNITY_SETUP_INSTANCE_ID( IN );
+	UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX( IN );
+
+	const half2 screenPos = IN.uv.xy;
+
+	const half depthSample = SampleDepth0( screenPos );
+
+	const half2 occlusionLinearEyeDepth = ComputeCombineDownsampledOcclusionFromTemporal( screenPos, depthSample );
+
+	const half4 occlusionRGBA = CalcOcclusion( occlusionLinearEyeDepth.x, occlusionLinearEyeDepth.y );
+
+	return half4( occlusionRGBA.rgb, 1 );
+}
+
+
+half4 ApplyCombineFromTemporal( const v2f_in IN )
+{
+	UNITY_SETUP_INSTANCE_ID( IN );
+	UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX( IN );
+
+	const half2 screenPos = IN.uv.xy;
+
+	const half depthSample = SampleDepth0( screenPos );
+
+	const half2 occlusionLinearEyeDepth = ComputeCombineDownsampledOcclusionFromTemporal( screenPos, depthSample );
+
+	const half4 occlusionRGBA = CalcOcclusion( occlusionLinearEyeDepth.x, occlusionLinearEyeDepth.y );
+
+	return half4( ( occlusionLinearEyeDepth.y < HALF_MAX )?occlusionRGBA.rgb:(1).xxx, 1 );
+}
+
+
+PostEffectOutputTemporal ApplyDebugTemporal( const v2f_in IN, const bool aUseMotionVectors )
+{
+	UNITY_SETUP_INSTANCE_ID( IN );
+	UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX( IN );
+
+	const float2 screenPos = IN.uv.xy;
+
+	const half2 occlusionDepth = FetchOcclusionDepth( screenPos );
+
+	PostEffectOutputTemporal OUT;
+
+	if( occlusionDepth.y < HALF_MAX )
+	{
+		const half linear01Depth = occlusionDepth.y * ONE_OVER_DEPTH_SCALE;
+		const half sampledDepth = Linear01ToSampledDepth( linear01Depth );
+		const half linearEyeDepth = occlusionDepth.y * _AO_BufDepthToLinearEye;
+
+		half occlusion;
+		const half4 temporalAcc = TemporalFilter( screenPos, occlusionDepth.x, sampledDepth, linearEyeDepth, linear01Depth, aUseMotionVectors, occlusion );
+
+		const half4 occlusionRGBA = CalcOcclusion( occlusion, linearEyeDepth );
+
+		OUT.occlusionColor = occlusionRGBA;
+		OUT.temporalAcc = temporalAcc;
+	}
+	else
+	{
+		OUT.occlusionColor = half4( (1).xxxx );
+		OUT.temporalAcc = half4( (1).xxxx );
+	}
+
+	return OUT;
+}
+
+
+#endif

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/ApplyPostEffect.cginc.meta
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/ApplyPostEffect.cginc.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 4f6e1460bc909e1459e29dbab8171ec9
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/Blur.shader
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/Blur.shader
@@ -1,0 +1,54 @@
+// Amplify Occlusion 2 - Robust Ambient Occlusion for Unity
+// Copyright (c) Amplify Creations, Lda <info@amplify.pt>
+
+Shader "Hidden/Amplify Occlusion/Blur"
+{
+	Properties { }
+	CGINCLUDE
+		#pragma vertex vert
+		#pragma fragment frag
+		#pragma target 3.0
+		#pragma exclude_renderers gles d3d11_9x n3ds
+
+		#include "Common.cginc"
+		#include "BlurFunctions.cginc"
+	ENDCG
+
+
+	SubShader
+	{
+		ZTest Always Cull Off ZWrite Off
+
+		// 0 => BLUR HORIZONTAL R:1
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return blur1D_1x( IN, half2( _AO_CurrOcclusionDepth_TexelSize.x, 0 ) ); } ENDCG }
+
+		// 1 => BLUR VERTICAL R:1
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return blur1D_1x( IN, half2( 0, _AO_CurrOcclusionDepth_TexelSize.y ) ); } ENDCG }
+
+		// 2 => BLUR HORIZONTAL R:2
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return blur1D_2x( IN, half2( _AO_CurrOcclusionDepth_TexelSize.x, 0 ) ); } ENDCG }
+
+		// 3 => BLUR VERTICAL R:2
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return blur1D_2x( IN, half2( 0, _AO_CurrOcclusionDepth_TexelSize.y ) ); } ENDCG }
+
+		// 4 => BLUR HORIZONTAL R:3
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return blur1D_3x( IN, half2( _AO_CurrOcclusionDepth_TexelSize.x, 0 ) ); } ENDCG }
+
+		// 5 => BLUR VERTICAL R:3
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return blur1D_3x( IN, half2( 0, _AO_CurrOcclusionDepth_TexelSize.y ) ); } ENDCG }
+
+		// 6 => BLUR HORIZONTAL R:4
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return blur1D_4x( IN, half2( _AO_CurrOcclusionDepth_TexelSize.x, 0 ) ); } ENDCG }
+
+		// 7 => BLUR VERTICAL R:4
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return blur1D_4x( IN, half2( 0, _AO_CurrOcclusionDepth_TexelSize.y ) ); } ENDCG }
+
+		// 8 => BLUR HORIZONTAL INTENSITY
+		Pass { CGPROGRAM half  frag( v2f_in IN ) : SV_Target { return blur1D_Intensity( IN, half2( _AO_CurrMotionIntensity_TexelSize.x, 0 ) ); } ENDCG }
+
+		// 9 => BLUR VERTICAL INTENSITY
+		Pass { CGPROGRAM half  frag( v2f_in IN ) : SV_Target { return blur1D_Intensity( IN, half2( 0, _AO_CurrMotionIntensity_TexelSize.y ) ); } ENDCG }
+	}
+
+	Fallback Off
+}

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/Blur.shader.meta
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/Blur.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 721d4727a93c1e548a5c6160a6229427
+timeCreated: 1449343856
+licenseType: Pro
+ShaderImporter:
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/BlurFunctions.cginc
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/BlurFunctions.cginc
@@ -1,0 +1,192 @@
+// Amplify Occlusion 2 - Robust Ambient Occlusion for Unity
+// Copyright (c) Amplify Creations, Lda <info@amplify.pt>
+
+#ifndef AMPLIFY_AO_BLURFUNCTIONS
+#define AMPLIFY_AO_BLURFUNCTIONS
+
+
+float		_AO_BlurSharpness;
+
+inline half ComputeSharpness( half linearEyeDepth )
+{
+	return _AO_BlurSharpness * ( saturate( 1 - linearEyeDepth ) + 0.01 );
+}
+
+inline half ComputeFalloff( const int radius )
+{
+	return 2.0 / ( radius * radius );
+}
+
+inline half2 CrossBilateralWeight( const half2 r, half2 d, half d0, const half sharpness, const half falloff )
+{
+	half2 diff = ( d0 - d ) * sharpness;
+	return exp2( -( r * r ) * falloff - diff * diff );
+}
+
+inline half4 CrossBilateralWeight( const half4 r, half4 d, half d0, const half sharpness, const half falloff )
+{
+	half4 diff = ( d0 - d ) * sharpness;
+	return exp2( -( r * r ) * falloff - diff * diff );
+}
+
+
+half4 blur1D_1x( v2f_in IN, half2 deltaUV )
+{
+	UNITY_SETUP_INSTANCE_ID( IN );
+	UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX( IN );
+
+	const half2 occlusionDepth = FetchOcclusionDepth( IN.uv );
+
+	const half occlusion = occlusionDepth.x;
+	const half depth = occlusionDepth.y;
+
+	const half2 offset1 = 1.55 * deltaUV;
+
+	half4 s1;
+	s1.xy = FetchOcclusionDepth( IN.uv + offset1 ).xy;
+	s1.zw = FetchOcclusionDepth( IN.uv - offset1 ).xy;
+
+	const half linearEyeDepth = occlusionDepth.y * _AO_BufDepthToLinearEye;
+	
+	const half sharpness = ComputeSharpness( linearEyeDepth );
+	const half falloff = ComputeFalloff( 2 );
+
+	const half2 w1 = CrossBilateralWeight( ( 1.0 ).xx, s1.yw, depth, sharpness, falloff );
+
+	half ao = occlusion + dot( s1.xz, w1 );
+	ao /= 1.0 + dot( ( 1.0 ).xx, w1 );
+
+	return half4( ao, depth, 0.0, 0.0 );
+}
+
+half4 blur1D_2x( v2f_in IN, half2 deltaUV )
+{
+	UNITY_SETUP_INSTANCE_ID( IN );
+	UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX( IN );
+
+	const half2 occlusionDepth = FetchOcclusionDepth( IN.uv );
+
+	const half occlusion = occlusionDepth.x;
+	const half depth = occlusionDepth.y;
+
+	const half2 offset1 = 1.2 * deltaUV;
+	const half2 offset2 = 2.5 * deltaUV;
+
+	half4 s1, s2;
+	s2.zw = FetchOcclusionDepth( IN.uv - offset2 ).xy;
+	s1.zw = FetchOcclusionDepth( IN.uv - offset1 ).xy;
+	s1.xy = FetchOcclusionDepth( IN.uv + offset1 ).xy;
+	s2.xy = FetchOcclusionDepth( IN.uv + offset2 ).xy;
+
+	const half linearEyeDepth = occlusionDepth.y * _AO_BufDepthToLinearEye;
+
+	const half sharpness = ComputeSharpness( linearEyeDepth );
+	const half falloff = ComputeFalloff( 4 );
+
+	const half4 w12 = CrossBilateralWeight( half4( 1, 1, 2, 2 ), half4( s1.yw, s2.yw ), depth, sharpness, falloff );
+
+	half ao = occlusion + dot( half4( s1.xz, s2.xz ), w12 );
+	ao /= 1.0 + dot( ( 1.0 ).xxxx, w12 );
+
+	return half4( ao, depth, 0.0, 0.0 );
+}
+
+
+half4 blur1D_3x( v2f_in IN, half2 deltaUV )
+{
+	UNITY_SETUP_INSTANCE_ID( IN );
+	UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX( IN );
+
+	const half2 occlusionDepth = FetchOcclusionDepth( IN.uv );
+
+	const half occlusion = occlusionDepth.x;
+	const half depth = occlusionDepth.y;
+
+	const half2 offset1 = 1.0 * deltaUV;
+	const half2 offset2 = 2.2 * deltaUV;
+	const half2 offset3 = 3.5 * deltaUV;
+
+	half4 s1, s2, s3;
+	s3.zw = FetchOcclusionDepth( IN.uv - offset3 ).xy;
+	s2.zw = FetchOcclusionDepth( IN.uv - offset2 ).xy;
+	s1.zw = FetchOcclusionDepth( IN.uv - offset1 ).xy;
+	s1.xy = FetchOcclusionDepth( IN.uv + offset1 ).xy;
+	s2.xy = FetchOcclusionDepth( IN.uv + offset2 ).xy;
+	s3.xy = FetchOcclusionDepth( IN.uv + offset3 ).xy;
+
+	const half linearEyeDepth = occlusionDepth.y * _AO_BufDepthToLinearEye;
+
+	const half sharpness = ComputeSharpness( linearEyeDepth );
+	const half falloff = ComputeFalloff( 6 );
+
+	const half4 w12 = CrossBilateralWeight( half4( 1, 1, 2, 2 ), half4( s1.yw, s2.yw ), depth, sharpness, falloff );
+	const half2 w3 = CrossBilateralWeight( ( 3 ).xx, s3.yw, depth, sharpness, falloff );
+
+	half ao = occlusion + dot( half4( s1.xz, s2.xz ), w12 ) + dot( s3.xz, w3 );
+	ao /= 1.0 + dot( ( 1.0 ).xxxx, w12 ) + dot( ( 1 ).xx, w3 );
+
+	return half4( ao, depth, 0.0, 0.0 );
+}
+
+
+half4 blur1D_4x( v2f_in IN, half2 deltaUV )
+{
+	UNITY_SETUP_INSTANCE_ID( IN );
+	UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX( IN );
+
+	const half2 occlusionDepth = FetchOcclusionDepth( IN.uv );
+
+	const half occlusion = occlusionDepth.x;
+	const half depth = occlusionDepth.y;
+
+	const half2 offset1 = 1.1 * deltaUV;
+	const half2 offset2 = 2.2 * deltaUV;
+	const half2 offset3 = 3.3 * deltaUV;
+	const half2 offset4 = 4.5 * deltaUV;
+
+	half4 s1, s2, s3, s4;
+	s4.zw = FetchOcclusionDepth( IN.uv - offset4 ).xy;
+	s3.zw = FetchOcclusionDepth( IN.uv - offset3 ).xy;
+	s2.zw = FetchOcclusionDepth( IN.uv - offset2 ).xy;
+	s1.zw = FetchOcclusionDepth( IN.uv - offset1 ).xy;
+	s1.xy = FetchOcclusionDepth( IN.uv + offset1 ).xy;
+	s2.xy = FetchOcclusionDepth( IN.uv + offset2 ).xy;
+	s3.xy = FetchOcclusionDepth( IN.uv + offset3 ).xy;
+	s4.xy = FetchOcclusionDepth( IN.uv + offset4 ).xy;
+
+	const half linearEyeDepth = occlusionDepth.y * _AO_BufDepthToLinearEye;
+
+	const half sharpness = ComputeSharpness( linearEyeDepth );
+	const half falloff = ComputeFalloff( 8 );
+
+	const half4 w12 = CrossBilateralWeight( half4( 1, 1, 2, 2 ), half4( s1.yw, s2.yw ), depth, sharpness, falloff );
+	const half4 w34 = CrossBilateralWeight( half4( 3, 3, 4, 4 ), half4( s3.yw, s4.yw ), depth, sharpness, falloff );
+
+	half ao = occlusion + dot( half4( s1.xz, s2.xz ), w12 ) + dot( half4( s3.xz, s4.xz ), w34 );
+	ao /= 1.0 + dot( ( 1.0 ).xxxx, w12 ) + dot( ( 1 ).xxxx, w34 );
+
+	return half4( ao, depth, 0.0, 0.0 );
+}
+
+
+half4 blur1D_Intensity( v2f_in IN, half2 deltaUV )
+{
+	UNITY_SETUP_INSTANCE_ID( IN );
+	UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX( IN );
+
+	half3 c;
+
+	c.x = FetchMotionIntensity( IN.uv );
+	c.y = FetchMotionIntensity( IN.uv + deltaUV * 1.5 );
+	c.z = FetchMotionIntensity( IN.uv - deltaUV * 1.5 );
+
+	half2 c2;
+	c2.x = FetchMotionIntensity( IN.uv + deltaUV * 3.3 );
+	c2.y = FetchMotionIntensity( IN.uv - deltaUV * 3.3 );
+
+	const half outV = saturate( dot( half3( 0.30, 0.25, 0.25 ), c ) + dot( (0.15).xx, c2 ) );
+
+	return outV;
+}
+
+#endif

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/BlurFunctions.cginc.meta
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/BlurFunctions.cginc.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 858fbcabf8fbfcf46bef60ce5729a5ce
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/Common.cginc
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/Common.cginc
@@ -1,0 +1,165 @@
+// Amplify Occlusion 2 - Robust Ambient Occlusion for Unity
+// Copyright (c) Amplify Creations, Lda <info@amplify.pt>
+
+#ifndef AMPLIFY_AO_COMMON_INCLUDED
+#define AMPLIFY_AO_COMMON_INCLUDED
+
+#pragma multi_compile_instancing
+
+#include "UnityCG.cginc"
+
+
+#if !defined( UNITY_DECLARE_DEPTH_TEXTURE )
+#define UNITY_DECLARE_DEPTH_TEXTURE(tex) sampler2D_float tex
+#endif
+
+#if !defined( UNITY_DECLARE_SCREENSPACE_TEXTURE )
+#define UNITY_DECLARE_SCREENSPACE_TEXTURE(tex) sampler2D tex;
+#endif
+
+#if !defined( UNITY_SAMPLE_SCREENSPACE_TEXTURE )
+#define UNITY_SAMPLE_SCREENSPACE_TEXTURE(tex, uv) tex2D(tex, uv)
+#endif
+
+#if !defined( UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX )
+#define UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(x)
+#endif
+
+
+inline float2 AO_ComputeScreenPos( float4 aVertex )
+{
+	return ComputeScreenPos( aVertex ).xy;
+}
+
+
+#if defined(UNITY_STEREO_INSTANCING_ENABLED) || defined(UNITY_STEREO_MULTIVIEW_ENABLED)
+UNITY_DECLARE_SCREENSPACE_TEXTURE( _CameraMotionVectorsTexture );
+#else
+sampler2D_half _CameraMotionVectorsTexture;
+#endif
+
+float4	_CameraMotionVectorsTexture_TexelSize;
+
+inline half2 FetchMotion( const half2 aUV )
+{
+	return UNITY_SAMPLE_SCREENSPACE_TEXTURE( _CameraMotionVectorsTexture, UnityStereoTransformScreenSpaceTex( aUV) ).rg;
+}
+
+
+UNITY_DECLARE_SCREENSPACE_TEXTURE( _AO_CurrMotionIntensity );
+float4	_AO_CurrMotionIntensity_TexelSize;
+
+inline half FetchMotionIntensity( const half2 aUV )
+{
+	return  UNITY_SAMPLE_SCREENSPACE_TEXTURE( _AO_CurrMotionIntensity, UnityStereoTransformScreenSpaceTex( aUV ) ).r;
+}
+
+
+UNITY_DECLARE_SCREENSPACE_TEXTURE( _AO_CurrOcclusionDepth );
+float4	_AO_CurrOcclusionDepth_TexelSize;
+
+inline half2 FetchOcclusionDepth( const half2 aUV )
+{
+	return UNITY_SAMPLE_SCREENSPACE_TEXTURE( _AO_CurrOcclusionDepth, UnityStereoTransformScreenSpaceTex( aUV ) ).rg;
+}
+
+
+UNITY_DECLARE_DEPTH_TEXTURE( _CameraDepthTexture );
+half4	_CameraDepthTexture_TexelSize;
+
+inline half SampleDepth0( const half2 aScreenPos )
+{
+	return SAMPLE_DEPTH_TEXTURE_LOD( _CameraDepthTexture, half4( UnityStereoTransformScreenSpaceTex( aScreenPos ), 0, 0 ) );
+}
+
+UNITY_DECLARE_SCREENSPACE_TEXTURE( _AO_SourceDepthMipmap );
+half4		_AO_SourceDepthMipmap_TexelSize;
+
+inline half SampleDepth( const half2 aScreenPos, half aLOD )
+{
+	return SAMPLE_DEPTH_TEXTURE_LOD( _AO_SourceDepthMipmap, half4( UnityStereoTransformScreenSpaceTex( aScreenPos ), 0, aLOD ) );
+}
+
+
+UNITY_DECLARE_SCREENSPACE_TEXTURE( _CameraDepthNormalsTexture );
+
+inline half4 FetchDepthNormals( const half2 aScreenPos )
+{
+	return UNITY_SAMPLE_SCREENSPACE_TEXTURE( _CameraDepthNormalsTexture, UnityStereoTransformScreenSpaceTex( aScreenPos ) );
+}
+
+
+UNITY_DECLARE_SCREENSPACE_TEXTURE( _AO_TemporalAccumm );
+float4	_AO_TemporalAccumm_TexelSize;
+
+inline half4 FetchTemporal( const half2 aScreenPos )
+{
+	return UNITY_SAMPLE_SCREENSPACE_TEXTURE( _AO_TemporalAccumm, UnityStereoTransformScreenSpaceTex( aScreenPos ) );
+}
+
+
+UNITY_DECLARE_SCREENSPACE_TEXTURE( _AO_GBufferNormals );
+
+inline half4 FetchGBufferNormals( const half2 aScreenPos )
+{
+	return UNITY_SAMPLE_SCREENSPACE_TEXTURE( _AO_GBufferNormals, UnityStereoTransformScreenSpaceTex( aScreenPos ) );
+}
+
+inline half3 FetchGBufferNormalWS( const half2 aScreenPos, const bool aIsGBufferOctaEnconded  )
+{
+	const half4 gbuffer2 = FetchGBufferNormals( aScreenPos );
+
+	half3 N = gbuffer2.rgb * 2.0 - 1.0;
+
+	if ( ( aIsGBufferOctaEnconded == true ) && ( gbuffer2.a < 1 ) )
+	{
+		N.z = 1 - abs( N.x ) - abs( N.y );
+		N.xy = ( N.z >= 0 ) ? N.xy : ( ( 1 - abs( N.yx ) ) * sign( N.xy ) );
+	}
+
+	return N;
+}
+
+
+UNITY_DECLARE_SCREENSPACE_TEXTURE( _AO_CurrDepthSource );
+half4		_AO_CurrDepthSource_TexelSize;;
+
+inline half FetchCurrDepthSource( const half2 aScreenPos )
+{
+	return UNITY_SAMPLE_SCREENSPACE_TEXTURE( _AO_CurrDepthSource, UnityStereoTransformScreenSpaceTex( aScreenPos ) );
+}
+
+
+#include "CommonFunctions.cginc"
+
+
+v2f_out vert( appdata v )
+{
+	v2f_out o;
+	UNITY_SETUP_INSTANCE_ID( v );
+	UNITY_TRANSFER_INSTANCE_ID( v, o );
+	UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO( o );
+
+	float4 vertex = float4( v.vertex.xy * 2.0 - 1.0, 0.0, 1.0 );
+
+#ifdef UNITY_HALF_TEXEL_OFFSET
+	vertex.xy += ( 1.0 / _AO_Target_TexelSize.zw ) * float2( -1, 1 );
+#endif
+
+	o.pos = vertex;
+
+#ifdef UNITY_SINGLE_PASS_STEREO
+	#if UNITY_UV_STARTS_AT_TOP
+		o.uv = float2( v.uv.x, 1.0 - v.uv.y );
+	#else
+		o.uv = v.uv;
+	#endif
+#else
+	o.uv = AO_ComputeScreenPos( vertex );
+#endif
+
+	return o;
+}
+
+
+#endif

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/Common.cginc.meta
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/Common.cginc.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 5f16bb82b4f4448dc9f754decd0f8796
+timeCreated: 1521647483
+licenseType: Pro
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/CommonFunctions.cginc
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/CommonFunctions.cginc
@@ -1,0 +1,201 @@
+// Amplify Occlusion 2 - Robust Ambient Occlusion for Unity
+// Copyright (c) Amplify Creations, Lda <info@amplify.pt>
+
+#ifndef AMPLIFY_AO_COMMON_FUNCTIONS_INCLUDED
+#define AMPLIFY_AO_COMMON_FUNCTIONS_INCLUDED
+
+#define PIXEL_RADIUS_LIMIT ( 512 )
+
+#define HALF_MAX        65504.0 // (2 - 2^-10) * 2^15
+#define HALF_MAX_MINUS1 65472.0 // (2 - 2^-9) * 2^15
+#define DEPTH_EPSILON	1e-6
+#define INTENSITY_THRESHOLD 1e-4
+
+#if defined( SHADER_API_MOBILE )
+#define DEPTH_SCALE 16376.0
+#else
+#define DEPTH_SCALE 65504.0
+#endif
+
+#define ONE_OVER_DEPTH_SCALE ( 1.0 / DEPTH_SCALE )
+
+float		_AO_TemporalMotionSensibility;
+half		_AO_TemporalDirections;
+half		_AO_TemporalOffsets;
+half		_AO_HalfProjScale;
+half		_AO_Radius;
+float		_AO_BufDepthToLinearEye;
+
+inline half DecAO( const half ao )
+{
+	return sqrt( ao );
+}
+
+inline half EncAO( const half ao )
+{
+	return saturate( ao * ao );
+}
+
+inline half DecDepth( const float2 aEncodedDepth )
+{
+	return DecodeFloatRG( aEncodedDepth );
+}
+
+inline half2 EncDepth( const half aDepth )
+{
+	return EncodeFloatRG( aDepth );
+}
+
+float2		_AO_FadeParams;
+float4		_AO_FadeValues;
+half4		_AO_Levels;
+half4		_AO_FadeToTint;
+half		_AO_PowExponent;
+
+inline half ComputeDistanceFade( const half distance )
+{
+	return saturate( max( 0.0, distance - _AO_FadeParams.x ) * _AO_FadeParams.y );
+}
+
+inline half4 CalcOcclusion( const half aOcclusion, const half aLinearDepth )
+{
+	const half distanceFade = ComputeDistanceFade( aLinearDepth );
+
+	const half exponent = lerp( _AO_PowExponent, _AO_FadeValues.z, distanceFade );
+
+	const half occlusion = pow( max( aOcclusion, 0.0 ), exponent );
+
+	half3 tintedOcclusion = lerp( _AO_Levels.rgb, _AO_FadeToTint.rgb, distanceFade );
+
+	tintedOcclusion = lerp( tintedOcclusion, ( 1 ).xxx, occlusion.xxx );
+
+	const half intensity = lerp( _AO_Levels.a, _AO_FadeValues.x, distanceFade );
+
+	return lerp( ( 1 ).xxxx, half4( tintedOcclusion.rgb, occlusion ), intensity );
+}
+
+inline float LinearEyeToSampledDepth( float linearEyeDepth )
+{
+	return ( 1.0 - linearEyeDepth * _ZBufferParams.w ) / ( linearEyeDepth * _ZBufferParams.z );
+}
+
+inline float2 LinearEyeToSampledDepth( float2 linearEyeDepth )
+{
+	return ( (1.0).xx - linearEyeDepth * ( _ZBufferParams.w ).xx ) / ( linearEyeDepth * ( _ZBufferParams.z ).xx );
+}
+
+inline float3 LinearEyeToSampledDepth( float3 linearEyeDepth )
+{
+	return ( (1.0).xxx - linearEyeDepth * ( _ZBufferParams.w ).xxx ) / ( linearEyeDepth * ( _ZBufferParams.z ).xxx );
+}
+
+inline float4 LinearEyeToSampledDepth( float4 linearEyeDepth )
+{
+	return ( (1.0).xxxx - linearEyeDepth * ( _ZBufferParams.w ).xxxx ) / ( linearEyeDepth * ( _ZBufferParams.z ).xxxx );
+}
+
+inline float Linear01ToSampledDepth( float linear01Depth )
+{
+	return ( 1.0 - linear01Depth * _ZBufferParams.y ) / ( linear01Depth * _ZBufferParams.x );
+}
+
+inline float2 Linear01ToSampledDepth( float2 linear01Depth )
+{
+	return ( (1.0).xx - linear01Depth * _ZBufferParams.y ) / ( linear01Depth * ( _ZBufferParams.x ).xx );
+}
+
+inline float4 Linear01ToSampledDepth( float4 linear01Depth )
+{
+	return ( (1.0).xxxx - linear01Depth * ( _ZBufferParams.y ).xxxx ) / ( linear01Depth * ( _ZBufferParams.x ).xxxx );
+}
+
+
+struct appdata
+{
+	float4 vertex : POSITION;
+	float2 uv : TEXCOORD0;
+	UNITY_VERTEX_INPUT_INSTANCE_ID
+};
+
+
+struct v2f_out
+{
+	float4 pos : SV_POSITION;
+	float2 uv : TEXCOORD0;
+	UNITY_VERTEX_INPUT_INSTANCE_ID
+	UNITY_VERTEX_OUTPUT_STEREO
+};
+
+
+struct v2f_in
+{
+	float4 pos : SV_POSITION;
+	float2 uv : TEXCOORD0;
+	UNITY_VERTEX_INPUT_INSTANCE_ID
+	UNITY_VERTEX_OUTPUT_STEREO
+};
+
+
+half4		_AO_Target_TexelSize;
+
+// Jimenez's "Interleaved Gradient Noise"
+inline half JimenezNoise( const half2 xyPixelPos )
+{
+	return frac( 52.9829189 * frac( dot( xyPixelPos, half2( 0.06711056, 0.00583715 ) ) ) );
+}
+
+
+inline void GetSpatialDirections_Offsets_JimenezNoise(	const half2 aScreenPos,
+											const half2 aTextureSizeZW,
+											out half outNoiseSpatialOffsets,
+											out half outNoiseSpatialDirections )
+{
+#if defined( SHADER_API_D3D9 ) || defined( SHADER_API_MOBILE )
+	// Spatial Offsets and Directions - s2016_pbs_activision_occlusion - Slide 93
+	const half2 xyPixelPos = ceil( UnityStereoTransformScreenSpaceTex( aScreenPos ) * aTextureSizeZW );
+	outNoiseSpatialOffsets = ( 1.0 / 4.0 ) * (half)( frac( ( xyPixelPos.y - xyPixelPos.x ) / 4.0 ) * 4.0 );
+
+	outNoiseSpatialDirections = JimenezNoise( (half2)xyPixelPos );
+#else
+	// Spatial Offsets and Directions - s2016_pbs_activision_occlusion - Slide 93
+	const int2 xyPixelPos = (int2)( UnityStereoTransformScreenSpaceTex( aScreenPos ) * aTextureSizeZW );
+	outNoiseSpatialOffsets = ( 1.0 / 4.0 ) * (half)( ( xyPixelPos.y - xyPixelPos.x ) & 3 );
+
+	outNoiseSpatialDirections = JimenezNoise( (half2)xyPixelPos );
+#endif
+}
+
+inline void GetSpatialDirections_Offsets(	const half2 aScreenPos,
+											const half2 aTextureSizeZW,
+											out half outNoiseSpatialOffsets,
+											out half outNoiseSpatialDirections )
+{
+#if defined( SHADER_API_D3D9 ) || defined( SHADER_API_MOBILE )
+	// Spatial Offsets and Directions - s2016_pbs_activision_occlusion - Slide 93
+	const half2 xyPixelPos = ceil( UnityStereoTransformScreenSpaceTex( aScreenPos ) * aTextureSizeZW );
+	outNoiseSpatialOffsets = ( 1.0 / 4.0 ) * (half)( frac( ( xyPixelPos.y - xyPixelPos.x ) / 4.0 ) * 4.0 );
+
+	// Noise Spatial Directions
+	// X   0  1  2  3
+	// Y0 00 05 10 15
+	// Y1 04 09 14 03
+	// Y2 08 13 02 07
+	// Y3 12 01 06 11
+	outNoiseSpatialDirections = ( 1.0 / 16.0 ) * (half)( ( ( frac( ( xyPixelPos.x + xyPixelPos.y ) / 4.0 ) * 4.0 ) * 4.0 ) + frac( xyPixelPos.x / 4.0 ) * 4.0 );
+#else
+	// Spatial Offsets and Directions - s2016_pbs_activision_occlusion - Slide 93
+	const int2 xyPixelPos = (int2)( UnityStereoTransformScreenSpaceTex( aScreenPos ) * aTextureSizeZW );
+	outNoiseSpatialOffsets = ( 1.0 / 4.0 ) * (half)( ( xyPixelPos.y - xyPixelPos.x ) & 3 );
+
+	// Noise Spatial Directions
+	// X   0  1  2  3
+	// Y0 00 05 10 15
+	// Y1 04 09 14 03
+	// Y2 08 13 02 07
+	// Y3 12 01 06 11
+	outNoiseSpatialDirections = ( 1.0 / 16.0 ) * (half)( ( ( ( xyPixelPos.x + xyPixelPos.y ) & 0x3 ) << 2 ) | ( xyPixelPos.x & 0x3 ) );
+#endif
+}
+
+
+#endif

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/CommonFunctions.cginc.meta
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/CommonFunctions.cginc.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 7f28133a2946e6b4dafae26e24d4fcc9
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/GTAO.cginc
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/GTAO.cginc
@@ -1,0 +1,406 @@
+﻿// Amplify Occlusion 2 - Robust Ambient Occlusion for Unity
+// Copyright (c) Amplify Creations, Lda <info@amplify.pt>
+
+#ifndef AMPLIFY_AO_GTAO
+#define AMPLIFY_AO_GTAO
+
+half4x4	_AO_CameraViewLeft;
+half4x4	_AO_CameraViewRight;
+
+#ifdef UNITY_SINGLE_PASS_STEREO
+half4x4	_AO_ProjMatrixLeft;
+half4x4	_AO_ProjMatrixRight;
+#endif
+
+
+half4		_AO_UVToView;
+
+half		_AO_Bias;
+
+half		_AO_ThicknessDecay;
+
+half4		_AO_Source_TexelSize;
+
+#define NORMALS_NONE ( 0 )
+#define NORMALS_CAMERA ( 1 )
+#define NORMALS_GBUFFER ( 2 )
+#define NORMALS_GBUFFER_OCTA_ENCODED ( 3 )
+
+
+inline half4 ConvertDepth( const half2 aUV, const half aSampledDepth )
+{
+	const half viewDepth = LinearEyeDepth( aSampledDepth );
+
+	#if defined(UNITY_REVERSED_Z)
+	const half sampledDepth = 1.0 - aSampledDepth;
+	#else
+	const half sampledDepth = aSampledDepth;
+	#endif
+
+	#ifdef UNITY_SINGLE_PASS_STEREO
+		const half4 clipPos = half4( aUV * 2.0 - 1.0, sampledDepth, 1.0f );
+
+		half4x4	projMatrix = ( unity_StereoEyeIndex == 0 ) ? _AO_ProjMatrixLeft : _AO_ProjMatrixRight;
+		half4 viewPos = mul( projMatrix, clipPos );
+
+		return half4( viewPos.xy * viewDepth, viewDepth, sampledDepth );
+	#else
+		return half4( ( aUV * _AO_UVToView.xy + _AO_UVToView.zw ) * viewDepth, viewDepth, sampledDepth );
+	#endif
+}
+
+inline half4 FetchPosition0( const half2 aUV )
+{
+	const half sampledDepth = SampleDepth0( aUV );
+
+	return ConvertDepth( aUV, sampledDepth );
+}
+
+
+inline half4 FetchPosition( const half2 aUV, half aLOD )
+{
+	const half sampledDepth = SampleDepth( aUV, aLOD );
+
+	return ConvertDepth( aUV, sampledDepth );
+}
+
+
+inline half3 FetchNormal( const half2 uv, const uint normalSource )
+{
+	if( normalSource == NORMALS_CAMERA )
+	{
+		const half4 cameraDepthNormals = FetchDepthNormals( uv );
+		const half3 normalScreenSpace = DecodeViewNormalStereo( cameraDepthNormals );
+
+		return half3( normalScreenSpace.xy, -normalScreenSpace.z );
+	}
+	else if ( (normalSource == NORMALS_GBUFFER) || (normalSource == NORMALS_GBUFFER_OCTA_ENCODED) )
+	{
+		const half3 normalWS = FetchGBufferNormalWS( uv, ( normalSource == NORMALS_GBUFFER_OCTA_ENCODED ) );
+
+	#ifdef UNITY_SINGLE_PASS_STEREO
+		const half4x4 cameraView = ( unity_StereoEyeIndex == 0 ) ? _AO_CameraViewLeft : _AO_CameraViewRight;
+	#else
+		const half4x4 cameraView = _AO_CameraViewLeft;
+	#endif
+
+		const half3 normalScreenSpace = normalize( mul( ( half3x3 ) cameraView, normalWS ) );
+
+		return half3( normalScreenSpace.xy, -normalScreenSpace.z );
+	}
+	else
+	{
+		const float3 c = FetchPosition0( uv ).xyz;
+		const float3 r = FetchPosition0( uv + half2( +1.0 , 0.0 ) * _AO_Target_TexelSize.xy ).xyz;
+		const float3 l = FetchPosition0( uv + half2( -1.0 , 0.0 ) * _AO_Target_TexelSize.xy ).xyz;
+		const float3 t = FetchPosition0( uv + half2(  0.0, +1.0 ) * _AO_Target_TexelSize.xy ).xyz;
+		const float3 b = FetchPosition0( uv + half2(  0.0, -1.0 ) * _AO_Target_TexelSize.xy ).xyz;
+		const float3 vr = ( r - c ), vl = ( c - l ), vt = ( t - c ), vb = ( c - b );
+		const float3 min_horiz = ( dot( vr, vr ) < dot( vl, vl ) ) ? vr : vl;
+		const float3 min_vert = ( dot( vt, vt ) < dot( vb, vb ) ) ? vt : vb;
+		const float3 normalScreenSpace = normalize( cross( min_horiz, min_vert ) );
+
+		return half3( -normalScreenSpace.x, -normalScreenSpace.y, -normalScreenSpace.z );
+	}
+}
+
+
+inline void GetFadeIntensity_Radius_Thickness(	const half aLinearDepth,
+												out half outIntensity,
+												out half outRadius,
+												out half outThicknessDecay )
+{
+	// Calc distance fade parameters
+	const half3 intensity_radius_thickness = lerp( half3( _AO_Levels.a, _AO_Radius, _AO_ThicknessDecay ),
+												_AO_FadeValues.xyw,
+												( ComputeDistanceFade( aLinearDepth ) ).xxx );
+
+	outIntensity = intensity_radius_thickness.x;
+	outRadius = intensity_radius_thickness.y;
+	outThicknessDecay = intensity_radius_thickness.z;
+}
+
+
+inline half2 SampleStepsDynamicDepthMips(	const int aStepCount,
+											const half2 aScreenPos,
+											const half2 aSlideDir_x_TexelSize,
+											const half aStepRadius,
+											const half aInitialRayStep,
+											const half aTwoOverSquaredRadius,
+											const half aThicknessDecay,
+											const half3 aVpos,
+											const half3 aVdir,
+											out half2 outUv )
+{
+	half2 h = half2( -1.0, -1.0 );
+	half2 oUv = 0;
+
+	UNITY_UNROLL
+	for ( int s = 0; s < aStepCount; s++ )
+	{
+		const half2 uvOffset = aSlideDir_x_TexelSize * max( aStepRadius * ( (half)s + aInitialRayStep ), 1.0 + (half)s );
+
+		const half4 uv = aScreenPos.xyxy + float4( +uvOffset.xy, -uvOffset.xy );
+		outUv = uv.xy;
+		// ds.v / ||ds||
+		// dt.v / ||dt||
+		half3 ds, dt;
+
+		if( s == 0 )
+		{
+			ds = FetchPosition0( uv.xy ).xyz;
+			dt = FetchPosition0( uv.zw ).xyz;
+		}
+		else
+		{
+			const half2 offsetPixels = _AO_Source_TexelSize.zw * uvOffset.xy;
+			const half distancePixels = max( offsetPixels.x, offsetPixels.y );
+			const half mipLevel = max( log2( distancePixels ) * 0.70 - 2.0, 0.0 );
+
+			ds = FetchPosition( uv.xy , mipLevel ).xyz;
+			dt = FetchPosition( uv.zw , mipLevel ).xyz;
+		}
+
+		ds = ds - aVpos.xyz;
+		dt = dt - aVpos.xyz;
+
+		const half2 dsdt = half2( dot( ds, ds ), dot( dt, dt ) );
+		const half2 rLength = rsqrt( dsdt + ( 0.0001 ).xx );
+
+		half2 H = half2( dot( ds, aVdir ), dot( dt, aVdir ) ) * rLength.xy;
+
+		// "Conservative attenuation" - s2016_pbs_activision_occlusion - Slide 103
+		// "Our attenuation function is a linear blending from 1 to 0 from a given,
+		//  large enough distance, to the maximum search radius." GTAO - Page 4
+		const half2 attn = saturate( dsdt.xy * aTwoOverSquaredRadius.xx );
+
+		H = lerp( H, h, attn );
+
+		h.xy = ( H.xy > h.xy ) ? H.xy : lerp( H.xy, h.xy, aThicknessDecay.xx );
+	}
+
+	return h;
+}
+
+sampler2D _MainTex;
+
+inline half2 SampleSteps(	const int aStepCount,
+							const half2 aScreenPos,
+							const half2 aSlideDir_x_TexelSize,
+							const half aStepRadius,
+							const half aInitialRayStep,
+							const half aTwoOverSquaredRadius,
+							const half aThicknessDecay,
+							const half3 aVpos,
+							const half3 aVdir,
+							out half2 outUv,
+							out half4 outColor)
+{
+	half2 h = half2( -1.0, -1.0 );
+	outUv = 0;
+	outColor = 0;
+
+	UNITY_UNROLL
+	for ( int s = 0; s < aStepCount; s++ )
+	{
+		const half2 uvOffset = aSlideDir_x_TexelSize * max( aStepRadius * ( (half)s + aInitialRayStep ), 1.0 + (half)s );
+
+		// s2016_pbs_activision_occlusion - Slide 54
+
+		const half4 uv = aScreenPos.xyxy + float4( +uvOffset.xy, -uvOffset.xy );
+		//if (outUv.x == 0)
+		//outUv = uv.xy - aStepRadius * 0.001;
+		outUv = uv.xy;
+	
+
+		// ds.v / ||ds||
+		half3 ds = FetchPosition0( uv.xy ).xyz - aVpos.xyz;
+
+		// dt.v / ||dt||
+		half3 dt = FetchPosition0( uv.zw ).xyz - aVpos.xyz;
+
+		const half2 dsdt = half2( dot( ds, ds ), dot( dt, dt ) );
+		const half2 rLength = rsqrt( dsdt + ( 0.0001 ).xx );
+
+		//outColor += tex2D(_MainTex, uv.xy);
+
+		half2 H = half2( dot( ds, aVdir ), dot( dt, aVdir ) ) * rLength.xy;
+
+			
+
+		// "Conservative attenuation" - s2016_pbs_activision_occlusion - Slide 103
+		// "Our attenuation function is a linear blending from 1 to 0 from a given,
+		//  large enough distance, to the maximum search radius." GTAO - Page 4
+		const half2 attn = saturate( dsdt.xy * aTwoOverSquaredRadius.xx );
+
+		
+
+		H = lerp( H, h, attn );
+
+		h.xy = ( H.xy > h.xy ) ? H.xy : lerp( H.xy, h.xy, aThicknessDecay.xx );
+	}
+
+	return h;
+}
+
+
+
+void GetGTAO(	const v2f_in ifrag,
+				const bool useDynamicDepthMips,
+				const int directionCount,
+				const int stepCount,
+				const int normalSource,
+				out half outDepth,
+				out half4 outRGBA )
+{
+
+	const half2 screenPos = ifrag.uv.xy;
+
+	const half2 depthUVoffset = half2( 0.25, 0.25 ) * _AO_Target_TexelSize.xy; // Avoids occluded horizontal and vertical bands when using half resolution depth sampling.
+
+	const half2 sampleUVdepth = screenPos - depthUVoffset;
+
+	const half sampledDepth = SampleDepth0( sampleUVdepth );
+
+	
+
+	const half4 vpos = ConvertDepth( sampleUVdepth, sampledDepth );
+
+	half intensity, radius, thicknessDecay;
+	GetFadeIntensity_Radius_Thickness( vpos.z, intensity, radius, thicknessDecay );
+
+	//UNITY_BRANCH
+	#if defined(UNITY_REVERSED_Z)
+	if( ( sampledDepth <= DEPTH_EPSILON ) || ( intensity < INTENSITY_THRESHOLD ) )
+	#else
+	if( ( sampledDepth >= ( 1.0 - DEPTH_EPSILON ) ) || ( intensity < INTENSITY_THRESHOLD ) )
+	#endif
+	{
+		outDepth = HALF_MAX;
+		outRGBA = half4( (1.0).xxxx );
+
+		return;
+	}
+	//outDepth = sampledDepth;
+	//return;
+
+	const half3 vnormal = FetchNormal( screenPos - depthUVoffset, normalSource );
+
+	const half3 vdir = normalize( (0).xxx - vpos.xyz );
+
+	const half vdirXYDot = dot( vdir.xy, vdir.xy );
+
+	const half radiusToScreen = radius * _AO_HalfProjScale;
+	const half screenRadius = max( min( radiusToScreen / vpos.z, PIXEL_RADIUS_LIMIT ), (half)stepCount );
+
+	const half twoOverSquaredRadius = 2.0 / ( radius * radius );
+
+	const half stepRadius = screenRadius / ( (half)stepCount + 1.0 );
+
+	half noiseSpatialOffsets, noiseSpatialDirections;
+	GetSpatialDirections_Offsets_JimenezNoise( screenPos, _AO_Target_TexelSize.zw, noiseSpatialOffsets, noiseSpatialDirections );
+
+	noiseSpatialDirections += _AO_TemporalDirections;
+
+	const half initialRayStep = frac( noiseSpatialOffsets + _AO_TemporalOffsets );
+
+	const half piOver_directionCount = UNITY_PI / (half)directionCount;
+	const half noiseSpatialDirections_x_piOver_directionCount = noiseSpatialDirections * piOver_directionCount;
+
+	half occlusionAcc = 0.0;
+	half4 colorBleed = 0;
+
+	for ( int dirCnt = 0; dirCnt < directionCount; dirCnt++ )
+	{
+		const half angle = (half)dirCnt * piOver_directionCount + noiseSpatialDirections_x_piOver_directionCount;
+
+		const half2 cos_sin = half2( cos( angle ), sin( angle ) );
+
+		const half3 sliceDir = half3( cos_sin.xy, 0.0 );
+
+		half wallDarkeningCorrection = dot( vnormal, cross( vdir, sliceDir ) ) * vdirXYDot;
+		wallDarkeningCorrection = wallDarkeningCorrection * wallDarkeningCorrection;
+
+		const half2 slideDir_x_TexelSize = sliceDir.xy * _AO_Target_TexelSize.xy;
+
+		half2 h;
+		half4 aColorBleed = 0;
+		half2 oUv = 0;
+		half4 oColor =0;
+
+		if( useDynamicDepthMips == true )
+		{
+			h = SampleStepsDynamicDepthMips(	stepCount,
+												screenPos,
+												slideDir_x_TexelSize,
+												stepRadius,
+												initialRayStep,
+												twoOverSquaredRadius,
+												thicknessDecay,
+												vpos.xyz,
+												vdir,
+												oUv );
+		}
+		else
+		{
+			h = SampleSteps(	stepCount,
+								screenPos,
+								slideDir_x_TexelSize,
+								stepRadius,
+								initialRayStep,
+								twoOverSquaredRadius,
+								thicknessDecay,
+								vpos.xyz,
+								vdir,
+								oUv,
+								oColor);
+		}
+
+		// "Project (and normalize) the normal to the slice plane for the integration" - s2016_pbs_activision_occlusion - Slide 62
+		const half3 normalSlicePlane = normalize( cross( sliceDir, vdir ) );
+		const half3 tangent = cross( vdir, normalSlicePlane );
+
+		// Gram-Schmidt process
+		// https://en.wikipedia.org/wiki/Gram-Schmidt_process
+		const half3 normalProjected = vnormal - normalSlicePlane * dot( vnormal, normalSlicePlane ); // There is no need to divide by ||np|| as np is normalized
+
+		const half projLength = length( normalProjected ) + 0.0001;
+		const half cos_gamma = clamp( dot( normalProjected, vdir /*w0*/ ) / projLength, -1.0, 1.0 ); // cos() = a.b / ( ||a|| * ||b|| )
+		const half gamma = -sign( dot( normalProjected, tangent ) ) * acos( cos_gamma );
+
+		h = acos( clamp( h, -1.0, 1.0 ) );
+
+		// "We have to clamp them with the normal hemisphere" - s2016_pbs_activision_occlusion - Slide 58
+		h.x = gamma + max( -h.x - gamma, -UNITY_HALF_PI );
+		h.y = gamma + min( +h.y - gamma, +UNITY_HALF_PI );
+
+		const half sin_gamma = sin( gamma );
+
+			
+		const half2 h2 = 2.0 * h;
+
+		//colorBleed += tex2D(_MainTex, normalProjected.xy);
+		
+		const half2 innerIntegral = ( -cos( h2 - gamma ) + cos_gamma + h2 * sin_gamma );
+
+		// "Multiply each slice contribution by the length of the projected normal" - s2016_pbs_activision_occlusion - Slide 62
+		occlusionAcc += ( projLength + wallDarkeningCorrection ) * 0.25 * ( innerIntegral.x + innerIntegral.y + _AO_Bias );
+
+		//colorBleed += tex2D(_MainTex, oUv);
+		//colorBleed += tex2D(_MainTex, screenPos + normalProjected * 0.1);
+		//colorBleed += lerp ( 0, oColor / stepCount, occlusionAcc);
+	}
+
+	occlusionAcc /= (half)directionCount;
+	//colorBleed /= (half)directionCount;
+
+	const half outAO = saturate( occlusionAcc );
+
+	outRGBA = half4( (1).xxx, outAO );
+	//outRGBA = colorBleed;
+	outRGBA.a = outAO;
+
+	outDepth = DEPTH_SCALE * Linear01Depth( sampledDepth );
+}
+
+#endif

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/GTAO.cginc.meta
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/GTAO.cginc.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 19bf4ddbaf23247e790ed5c05d3f2244
+timeCreated: 1522077311
+licenseType: Pro
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/Occlusion.shader
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/Occlusion.shader
@@ -1,0 +1,93 @@
+// Amplify Occlusion 2 - Robust Ambient Occlusion for Unity
+// Copyright (c) Amplify Creations, Lda <info@amplify.pt>
+
+Shader "Hidden/Amplify Occlusion/Occlusion"
+{
+	CGINCLUDE
+		#pragma vertex vert
+		#pragma fragment frag
+		#pragma target 3.0
+		#pragma exclude_renderers gles d3d11_9x n3ds
+
+		#include "Common.cginc"
+		#include "GTAO.cginc"
+		#include "OcclusionFunctions.cginc"
+		#include "TemporalFilter.cginc"
+	ENDCG
+
+	SubShader
+	{
+		ZTest Always
+		Cull Off
+		ZWrite Off
+
+		// 0-3 => FULL OCCLUSION - LOW QUALITY                    directionCount / sampleCount
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, false, 2, 4, NORMALS_NONE ); } ENDCG }
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, false, 2, 4, NORMALS_CAMERA ); } ENDCG }
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, false, 2, 4, NORMALS_GBUFFER ); } ENDCG }
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, false, 2, 4, NORMALS_GBUFFER_OCTA_ENCODED ); } ENDCG }
+
+		// 04-07 => FULL OCCLUSION / MEDIUM QUALITY
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, false, 2, 6, NORMALS_NONE ); } ENDCG }
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, false, 2, 6, NORMALS_CAMERA ); } ENDCG }
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, false, 2, 6, NORMALS_GBUFFER ); } ENDCG }
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, false, 2, 6, NORMALS_GBUFFER_OCTA_ENCODED ); } ENDCG }
+
+		// 08-11 => FULL OCCLUSION - HIGH QUALITY
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, false, 3, 8, NORMALS_NONE ); } ENDCG }
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, false, 3, 8, NORMALS_CAMERA ); } ENDCG }
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, false, 3, 8, NORMALS_GBUFFER ); } ENDCG }
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, false, 3, 8, NORMALS_GBUFFER_OCTA_ENCODED ); } ENDCG }
+
+		// 12-15 => FULL OCCLUSION / VERYHIGH QUALITY
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, false, 4, 10, NORMALS_NONE ); } ENDCG }
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, false, 4, 10, NORMALS_CAMERA ); } ENDCG }
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, false, 4, 10, NORMALS_GBUFFER ); } ENDCG }
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, false, 4, 10, NORMALS_GBUFFER_OCTA_ENCODED ); } ENDCG }
+
+
+		// 16-19 => FULL OCCLUSION - LOW QUALITY                    directionCount / sampleCount
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, true, 2, 4, NORMALS_NONE ); } ENDCG }
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, true, 2, 4, NORMALS_CAMERA ); } ENDCG }
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, true, 2, 4, NORMALS_GBUFFER ); } ENDCG }
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, true, 2, 4, NORMALS_GBUFFER_OCTA_ENCODED ); } ENDCG }
+
+		// 20-23 => FULL OCCLUSION / MEDIUM QUALITY
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, true, 2, 6, NORMALS_NONE ); } ENDCG }
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, true, 2, 6, NORMALS_CAMERA ); } ENDCG }
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, true, 2, 6, NORMALS_GBUFFER ); } ENDCG }
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, true, 2, 6, NORMALS_GBUFFER_OCTA_ENCODED ); } ENDCG }
+
+		// 24-27 => FULL OCCLUSION - HIGH QUALITY
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, true, 3, 8, NORMALS_NONE ); } ENDCG }
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, true, 3, 8, NORMALS_CAMERA ); } ENDCG }
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, true, 3, 8, NORMALS_GBUFFER ); } ENDCG }
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, true, 3, 8, NORMALS_GBUFFER_OCTA_ENCODED ); } ENDCG }
+
+		// 28-31 => FULL OCCLUSION / VERYHIGH QUALITY
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, true, 4, 10, NORMALS_NONE ); } ENDCG }
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, true, 4, 10, NORMALS_CAMERA ); } ENDCG }
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, true, 4, 10, NORMALS_GBUFFER ); } ENDCG }
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, true, 4, 10, NORMALS_GBUFFER_OCTA_ENCODED ); } ENDCG }
+
+		// 32 => CombineDownsampledOcclusionDepth
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return CombineDownsampledOcclusionDepth( IN );	} ENDCG	}
+
+		// 33 => Neighbor Motion Intensity
+		Pass { CGPROGRAM half2 frag( v2f_in IN ) : SV_Target { return NeighborMotionIntensity( IN ); } ENDCG }
+
+		// 34 => Clear Temporal
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return ClearTemporal( IN ); } ENDCG }
+
+		// 35 => ScaleDownCloserDepthEven
+		Pass { CGPROGRAM float frag( v2f_in IN ) : SV_Target { return ScaleDownCloserDepthEven( IN ); } ENDCG }
+
+		// 36 => ScaleDownCloserDepthEven_CameraDepthTexture
+		Pass { CGPROGRAM float frag( v2f_in IN ) : SV_Target { return ScaleDownCloserDepthEven_CameraDepthTexture( IN ); } ENDCG }
+
+		// 37 => Temporal
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return Temporal( IN, false ); } ENDCG }
+		Pass { CGPROGRAM half4 frag( v2f_in IN ) : SV_Target { return Temporal( IN, true ); } ENDCG }
+	}
+}
+

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/Occlusion.shader.meta
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/Occlusion.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: ca3c44b6d4f2d4d1095e1e783d9684ba
+timeCreated: 1499784251
+licenseType: Pro
+ShaderImporter:
+  defaultTextures:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/OcclusionFunctions.cginc
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/OcclusionFunctions.cginc
@@ -1,0 +1,198 @@
+// Amplify Occlusion 2 - Robust Ambient Occlusion for Unity
+// Copyright (c) Amplify Creations, Lda <info@amplify.pt>
+
+#ifndef AMPLIFY_AO_OCCLUSIONFUNCTIONS
+#define AMPLIFY_AO_OCCLUSIONFUNCTIONS
+
+
+half4 GTAO( const v2f_in ifrag, const bool useDynamicDepthMips, const int directionCount, const int sampleCount, const int normalSource )
+{
+	UNITY_SETUP_INSTANCE_ID( ifrag );
+	UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX( ifrag );
+
+	half outDepth;
+	half4 outRGBA;
+
+	GetGTAO( ifrag, useDynamicDepthMips, directionCount, sampleCount / 2, normalSource, outDepth, outRGBA );
+
+	// https://stackoverflow.com/questions/41566049/understanding-unitys-rgba-encoding-in-float-encodefloatrgba
+	//outRGBA = min(outRGBA, 0.9999);
+	//half packedRGBA = __DecodeFloatRGBA(outRGBA);
+
+	return half4(outRGBA.a, outDepth, 0, 0);
+}
+
+
+inline half4 ComputeCombineDownsampledOcclusionDepth( const half2 aScreenPos, const half aDepthSample )
+{
+	const half referenceDepth = LinearEyeDepth( aDepthSample );
+
+	const half intensity = lerp( _AO_Levels.a, _AO_FadeValues.x, ComputeDistanceFade( referenceDepth ) );
+
+	//UNITY_BRANCH
+	#if defined(UNITY_REVERSED_Z)
+	if( ( aDepthSample <= DEPTH_EPSILON ) || ( intensity < INTENSITY_THRESHOLD ) )
+	#else
+	if( ( aDepthSample >= ( 1.0 - DEPTH_EPSILON ) ) || ( intensity < INTENSITY_THRESHOLD ) )
+	#endif
+	{
+		return half4( 1.0, HALF_MAX, 0, 0 );
+	}
+
+	const half2 screenPosPixels = aScreenPos * _AO_CurrOcclusionDepth_TexelSize.zw;
+	const half2 screenPosPixelsFloor = floor( screenPosPixels );
+	const half2 screenPosPixelsDelta = screenPosPixels - screenPosPixelsFloor;
+
+	const half2 sPosAdjusted = screenPosPixelsFloor * _AO_CurrOcclusionDepth_TexelSize.xy + half2( 0.5, 0.5 ) * _AO_CurrOcclusionDepth_TexelSize.xy;
+	const half s = ( screenPosPixelsDelta.y < 0.5 )?-1.0:1.0;
+
+	half2 odC = FetchOcclusionDepth( sPosAdjusted );
+	half2 odL = FetchOcclusionDepth( sPosAdjusted + half2( -1.0, 0.0 ) * _AO_CurrOcclusionDepth_TexelSize.xy );
+	half2 odR = FetchOcclusionDepth( sPosAdjusted + half2( +1.0, 0.0 ) * _AO_CurrOcclusionDepth_TexelSize.xy );
+	half2 odM = FetchOcclusionDepth( sPosAdjusted + half2(  0.0,   s ) * _AO_CurrOcclusionDepth_TexelSize.xy );
+
+	const half4 o0123 = half4( odC.x, odL.x, odR.x, odM.x );
+	const half4 d0123 = half4( odC.y, odL.y, odR.y, odM.y );
+
+	half4 depthWeight0123 = saturate( 1.0 / ( abs( Linear01ToSampledDepth( d0123 * ONE_OVER_DEPTH_SCALE ) - ( aDepthSample ).xxxx ) * 32768 + 0.95 ) );
+
+	const half4 pixelDeltaWeight = half4( screenPosPixelsDelta.x * screenPosPixelsDelta.y + 0.5,
+											1.0 - screenPosPixelsDelta.x,
+											screenPosPixelsDelta.x,
+											0.80 );
+
+	depthWeight0123 = depthWeight0123 * depthWeight0123 * pixelDeltaWeight;
+
+	half weightOcclusion = dot( o0123, depthWeight0123 );
+
+	const half outOcclusion = saturate( weightOcclusion / dot( ( 1 ).xxxx, depthWeight0123 ) );
+
+	const half linearDepth01 = Linear01Depth( aDepthSample );
+
+	return half4( outOcclusion, DEPTH_SCALE * linearDepth01, 0, 0 );
+}
+
+
+half4 CombineDownsampledOcclusionDepth( const v2f_in ifrag )
+{
+	UNITY_SETUP_INSTANCE_ID( ifrag );
+	UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX( ifrag );
+
+	const half2 screenPos = ifrag.uv.xy;
+
+	const half depthSample = SampleDepth0( screenPos );
+
+	return ComputeCombineDownsampledOcclusionDepth( screenPos, depthSample );
+}
+
+
+inline half FetchNeighborMotion( const half2 aUV, const half aRadiusPixels, const half2 aCentralmv )
+{
+	half noiseSpatialOffsets, noiseSpatialDirections;
+	GetSpatialDirections_Offsets_JimenezNoise( aUV, _CameraMotionVectorsTexture_TexelSize.zw * 0.5, noiseSpatialOffsets, noiseSpatialDirections );
+
+	const half angle = ( noiseSpatialDirections ) * UNITY_PI;
+	const half2 cos_sin = half2( cos( angle ), sin( angle ) );
+	const half2 xy = ( aRadiusPixels * noiseSpatialOffsets + 8.0 ).xx * cos_sin;
+
+	const half2 xLyT = FetchMotion( half2( -xy.x, -xy.y ) * _CameraMotionVectorsTexture_TexelSize.xy + aUV );
+	const half2 xRyD = FetchMotion( half2( +xy.x, +xy.y ) * _CameraMotionVectorsTexture_TexelSize.xy + aUV );
+
+	const half2 xLyT_v = xLyT - aCentralmv;
+	const half2 xRyD_v = xRyD - aCentralmv;
+
+	const half2 sqrLength2 = half2( dot( xLyT_v, xLyT_v ), dot( xRyD_v, xRyD_v ) );
+	const half neighborMotion = max( sqrLength2.x, sqrLength2.y );
+	const half oneOverPixelDeltaSquared = 1.0 / ( _CameraMotionVectorsTexture_TexelSize.x * _CameraMotionVectorsTexture_TexelSize.x );
+
+	const half outNeighborMotion = saturate( neighborMotion * oneOverPixelDeltaSquared - 1.0 ) * _AO_TemporalMotionSensibility;
+
+	return outNeighborMotion;
+}
+
+
+half NeighborMotionIntensity( v2f_in IN )
+{
+	UNITY_SETUP_INSTANCE_ID( IN );
+	UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX( IN );
+
+	const float2 screenPos = IN.uv.xy;
+
+	const half depthSample = SampleDepth0( screenPos );
+
+	if( depthSample < HALF_MAX )
+	{
+		half linearEyeDepth = LinearEyeDepth( depthSample );
+
+		const half radius = lerp( _AO_Radius, _AO_FadeValues.y, ComputeDistanceFade( linearEyeDepth ) );
+		const half radiusToScreen = radius * _AO_HalfProjScale;
+		const half screenRadius = max( min( ( radiusToScreen / linearEyeDepth ), PIXEL_RADIUS_LIMIT ), 2 );
+
+		const half2 cMv = FetchMotion( screenPos );
+
+		const half motionNeighborDisoclusion = FetchNeighborMotion( screenPos, screenRadius, cMv );
+
+		return motionNeighborDisoclusion;
+	}
+	else
+	{
+		return 0;
+	}
+}
+
+
+half4 ClearTemporal( const v2f_in ifrag )
+{
+	UNITY_SETUP_INSTANCE_ID( ifrag );
+	UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX( ifrag );
+
+	return half4( EncAO( 0.99 ), 1.0, 1.0, 0.0 );
+}
+
+
+float ScaleDownCloserDepthEven( v2f_in IN )
+{
+	UNITY_SETUP_INSTANCE_ID( IN );
+	UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX( IN );
+
+	// Snap uv to source pixel center
+	const half2 screenPos = floor( ( IN.uv.xy + half2( 1.0, 1.0 ) * _AO_CurrDepthSource_TexelSize.xy ) * _AO_CurrDepthSource_TexelSize.zw ) * _AO_CurrDepthSource_TexelSize.xy - half2( 0.5, 0.5 ) * _AO_CurrDepthSource_TexelSize.xy;
+
+	const float d0 = FetchCurrDepthSource( screenPos + half2( 0.0, 0.0 ) * _AO_CurrDepthSource_TexelSize.xy );
+	const float d1 = FetchCurrDepthSource( screenPos + half2( 1.0, 0.0 ) * _AO_CurrDepthSource_TexelSize.xy );
+	const float d2 = FetchCurrDepthSource( screenPos + half2( 0.0, 1.0 ) * _AO_CurrDepthSource_TexelSize.xy );
+	const float d3 = FetchCurrDepthSource( screenPos + half2( 1.0, 1.0 ) * _AO_CurrDepthSource_TexelSize.xy );
+
+	#if defined(UNITY_REVERSED_Z)
+	const float closerDepth = max( d0, max( d1, max( d2, d3 ) ) );
+	#else
+	const float closerDepth = min( d0, min( d1, min( d2, d3 ) ) );
+	#endif
+
+	return closerDepth;
+}
+
+
+float ScaleDownCloserDepthEven_CameraDepthTexture( v2f_in IN )
+{
+	UNITY_SETUP_INSTANCE_ID( IN );
+	UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX( IN );
+
+	// Snap uv to source pixel center
+	const half2 screenPos = floor( ( IN.uv.xy + half2( 1.0, 1.0 ) * _CameraDepthTexture_TexelSize.xy ) * _CameraDepthTexture_TexelSize.zw ) * _CameraDepthTexture_TexelSize.xy - half2( 0.5, 0.5 ) * _CameraDepthTexture_TexelSize.xy;
+
+	const float d0 = SampleDepth0( screenPos + half2( 0.0, 0.0 ) * _CameraDepthTexture_TexelSize.xy );
+	const float d1 = SampleDepth0( screenPos + half2( 1.0, 0.0 ) * _CameraDepthTexture_TexelSize.xy );
+	const float d2 = SampleDepth0( screenPos + half2( 0.0, 1.0 ) * _CameraDepthTexture_TexelSize.xy );
+	const float d3 = SampleDepth0( screenPos + half2( 1.0, 1.0 ) * _CameraDepthTexture_TexelSize.xy );
+
+	#if defined(UNITY_REVERSED_Z)
+	const float closerDepth = max( d0, max( d1, max( d2, d3 ) ) );
+	#else
+	const float closerDepth = min( d0, min( d1, min( d2, d3 ) ) );
+	#endif
+
+	return closerDepth;
+}
+
+#endif

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/OcclusionFunctions.cginc.meta
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/OcclusionFunctions.cginc.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 03e610c22ca9f8c4298d97ae79125541
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/SRP.meta
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/SRP.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dbf766f4bfee1154c92bc652bd2205ed
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/SRP/ApplyPostProcessing.shader
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/SRP/ApplyPostProcessing.shader
@@ -1,0 +1,137 @@
+// Amplify Occlusion 2 - Robust Ambient Occlusion for Unity
+// Copyright (c) Amplify Creations, Lda <info@amplify.pt>
+
+Shader "Hidden/Amplify Occlusion/ApplyPostProcessing"
+{
+	HLSLINCLUDE
+		#pragma vertex vert
+		#pragma fragment frag
+		#pragma target 3.0
+		#pragma exclude_renderers gles d3d11_9x n3ds
+		#pragma multi_compile_instancing
+
+		#include "Common.hlsl"
+		#include "../../Resources/TemporalFilter.cginc"
+		#include "../../Resources/ApplyPostEffect.cginc"
+
+		//TEXTURE2D_SAMPLER2D( _MainTex, sampler_MainTex );
+		sampler2D _MainTex;
+		SamplerState sampler_MainTex;
+
+		PostEffectOutputTemporal ApplyPostEffectTemporal( v2f_in IN, const bool aUseMotionVectors )
+		{
+			UNITY_SETUP_INSTANCE_ID( IN );
+			UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX( IN );
+
+			const float2 screenPos = IN.uv.xy;
+
+			const half2 occlusionDepth = FetchOcclusionDepth( screenPos );
+
+			PostEffectOutputTemporal OUT;
+
+			const half4 srcColor = tex2D( _MainTex, UnityStereoTransformScreenSpaceTex( screenPos ) );
+
+			if( occlusionDepth.y < HALF_MAX )
+			{
+				const half linear01Depth = occlusionDepth.y * ONE_OVER_DEPTH_SCALE;
+				const half sampledDepth = Linear01ToSampledDepth( linear01Depth );
+				const half linearEyeDepth = occlusionDepth.y * _AO_BufDepthToLinearEye;
+
+				half occlusion;
+				const half4 temporalAcc = TemporalFilter( screenPos, occlusionDepth.x, sampledDepth, linearEyeDepth, linear01Depth, aUseMotionVectors, occlusion );
+
+				const half4 occlusionRGBA = CalcOcclusion( occlusion, linearEyeDepth );
+
+				const half4 outColor = half4( srcColor.rgb * lerp( (1).xxx, occlusionRGBA.rgb, (srcColor.a).xxx ), srcColor.a );
+
+				OUT.occlusionColor = outColor;
+				OUT.temporalAcc = temporalAcc;
+			}
+			else
+			{
+				OUT.occlusionColor = srcColor;
+				OUT.temporalAcc = half4( (1).xxxx );
+			}
+
+			return OUT;
+		}
+
+
+		half4 ApplyPostEffectCombineFromTemporal( v2f_in IN )
+		{
+			UNITY_SETUP_INSTANCE_ID( IN );
+			UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX( IN );
+
+			const half2 screenPos = IN.uv.xy;
+
+			const half depthSample = SampleDepth0( screenPos );
+
+			const half2 occlusionLinearEyeDepth = ComputeCombineDownsampledOcclusionFromTemporal( screenPos, depthSample );
+
+			const half4 occlusionRGBA = CalcOcclusion( occlusionLinearEyeDepth.x, occlusionLinearEyeDepth.y );
+			
+			const half4 srcColor = tex2D( _MainTex, UnityStereoTransformScreenSpaceTex( screenPos ) );
+
+			const half4 outColor = half4( srcColor.rgb * lerp( (1).xxx, occlusionRGBA.rgb, (srcColor.a).xxx ), srcColor.a );
+
+			return half4( ( occlusionLinearEyeDepth.y < HALF_MAX )?outColor: srcColor );
+		}
+
+
+		half4 ApplyPostEffect( v2f_in IN )
+		{
+			UNITY_SETUP_INSTANCE_ID( IN );
+			UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX( IN );
+
+			const half4 srcColor = tex2D( _MainTex, IN.uv);
+			half4 outColor = _ApplyPostEffect(IN, srcColor);
+
+			return lerp(srcColor, outColor, _AO_Levels.a);
+		}
+	ENDHLSL
+
+
+	SubShader
+	{
+		ZTest Always Cull Off ZWrite Off
+
+		// -- APPLICATION METHODS --------------------------------------------------------------
+		// 0 => APPLY DEBUG
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return ApplyDebug( IN ); } ENDHLSL }
+		// 1 => APPLY DEBUG Temporal
+		Pass { HLSLPROGRAM PostEffectOutputTemporal frag( v2f_in IN ) { return ApplyDebugTemporal( IN, false ); } ENDHLSL }
+		Pass { HLSLPROGRAM PostEffectOutputTemporal frag( v2f_in IN ) { return ApplyDebugTemporal( IN, true ); } ENDHLSL }
+
+		// 3 => NOT USED
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return half4( 255, 0, 255, 1 ); } ENDHLSL }
+		// 4 => NOT USED
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return half4( 255, 0, 255, 1 ); } ENDHLSL }
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return half4( 255, 0, 255, 1 ); } ENDHLSL }
+
+		// 6 => NOT USED
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return half4( 255, 0, 255, 1 ); } ENDHLSL }
+		// 7 => NOT USED
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return half4( 255, 0, 255, 1 ); } ENDHLSL }
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return half4( 255, 0, 255, 1 ); } ENDHLSL }
+
+		// 9 => APPLY POST-EFFECT
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return ApplyPostEffect( IN ); } ENDHLSL }
+		// 10 => APPLY POST-EFFECT Temporal
+		Pass { HLSLPROGRAM PostEffectOutputTemporal frag( v2f_in IN ) { return ApplyPostEffectTemporal( IN, false ); } ENDHLSL }
+		Pass { HLSLPROGRAM PostEffectOutputTemporal frag( v2f_in IN ) { return ApplyPostEffectTemporal( IN, true ); } ENDHLSL }
+
+		// 12 => NOT USED
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return half4( 255, 0, 255, 1 ); } ENDHLSL }
+
+		// 13 => NOT USED
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return half4( 255, 0, 255, 1 ); } ENDHLSL }
+
+		// 14 => APPLY DEBUG Combine from Temporal
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return ApplyDebugCombineFromTemporal( IN ); } ENDHLSL }
+
+		// 15 => APPLY POST-EFFECT Combine from Temporal
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return ApplyPostEffectCombineFromTemporal( IN ); } ENDHLSL }
+	}
+
+	Fallback Off
+}

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/SRP/ApplyPostProcessing.shader.meta
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/SRP/ApplyPostProcessing.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: b956e57e3e39b2747886ec5a31a31cc7
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/SRP/BlurPostProcessing.shader
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/SRP/BlurPostProcessing.shader
@@ -1,0 +1,54 @@
+// Amplify Occlusion 2 - Robust Ambient Occlusion for Unity
+// Copyright (c) Amplify Creations, Lda <info@amplify.pt>
+
+Shader "Hidden/Amplify Occlusion/BlurPostProcessing"
+{
+	Properties { }
+	HLSLINCLUDE
+		#pragma vertex vert
+		#pragma fragment frag
+		#pragma target 3.0
+		#pragma exclude_renderers gles d3d11_9x n3ds
+
+		#include "Common.hlsl"
+		#include "../../Resources/BlurFunctions.cginc"
+	ENDHLSL
+
+
+	SubShader
+	{
+		ZTest Always Cull Off ZWrite Off
+
+		// 0 => BLUR HORIZONTAL R:1
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return blur1D_1x( IN, half2( _AO_CurrOcclusionDepth_TexelSize.x, 0 ) ); } ENDHLSL }
+
+		// 1 => BLUR VERTICAL R:1
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return blur1D_1x( IN, half2( 0, _AO_CurrOcclusionDepth_TexelSize.y ) ); } ENDHLSL }
+
+		// 2 => BLUR HORIZONTAL R:2
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return blur1D_2x( IN, half2( _AO_CurrOcclusionDepth_TexelSize.x, 0 ) ); } ENDHLSL }
+
+		// 3 => BLUR VERTICAL R:2
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return blur1D_2x( IN, half2( 0, _AO_CurrOcclusionDepth_TexelSize.y ) ); } ENDHLSL }
+
+		// 4 => BLUR HORIZONTAL R:3
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return blur1D_3x( IN, half2( _AO_CurrOcclusionDepth_TexelSize.x, 0 ) ); } ENDHLSL }
+
+		// 5 => BLUR VERTICAL R:3
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return blur1D_3x( IN, half2( 0, _AO_CurrOcclusionDepth_TexelSize.y ) ); } ENDHLSL }
+
+		// 6 => BLUR HORIZONTAL R:4
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return blur1D_4x( IN, half2( _AO_CurrOcclusionDepth_TexelSize.x, 0 ) ); } ENDHLSL }
+
+		// 7 => BLUR VERTICAL R:4
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return blur1D_4x( IN, half2( 0, _AO_CurrOcclusionDepth_TexelSize.y ) ); } ENDHLSL }
+
+		// 8 => BLUR HORIZONTAL INTENSITY
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return blur1D_Intensity( IN, half2( _AO_CurrMotionIntensity_TexelSize.x, 0 ) ); } ENDHLSL }
+
+		// 9 => BLUR VERTICAL INTENSITY
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return blur1D_Intensity( IN, half2( 0, _AO_CurrMotionIntensity_TexelSize.y ) ); } ENDHLSL }
+	}
+
+	Fallback Off
+}

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/SRP/BlurPostProcessing.shader.meta
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/SRP/BlurPostProcessing.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: d70a28c10e6cc1d4ca72f22aa3cb6056
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/SRP/Common.hlsl
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/SRP/Common.hlsl
@@ -1,0 +1,195 @@
+// Amplify Occlusion 2 - Robust Ambient Occlusion for Unity
+// Copyright (c) Amplify Creations, Lda <info@amplify.pt>
+
+#ifndef AMPLIFY_AO_COMMON_HLSL
+#define AMPLIFY_AO_COMMON_HLSL
+
+//#include "Packages/com.unity.postprocessing/PostProcessing/Shaders/StdLib.hlsl"
+//#include "../../Resources/PostProcessingStdLib.hlsl"
+
+//#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DeclareDepthTexture.hlsl"
+#include "Packages/com.unity.postprocessing/PostProcessing/Shaders/StdLib.hlsl"
+//#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/UnityInstancing.hlsl"
+//#include "ShaderGraphLibrary/Functions.hlsl"
+
+
+#if !defined( UNITY_PI )
+#define UNITY_PI PI
+#endif
+
+#if !defined( UNITY_HALF_PI )
+#define UNITY_HALF_PI HALF_PI
+#endif
+
+
+float4		_ScreenToTargetScale;
+
+float4 ComputeScreenPos( float4 pos, float projectionSign )
+{
+  float4 o = pos * 0.5f;
+  o.xy = float2( o.x, o.y * projectionSign ) + o.w;
+  o.zw = pos.zw;
+
+  return o;
+}
+
+
+inline float2 AO_ComputeScreenPos( float4 aVertex )
+{
+	return ComputeScreenPos( aVertex, _ProjectionParams.x ).xy;
+}
+
+
+TEXTURE2D_SAMPLER2D(_CameraMotionVectorsTexture, sampler_CameraMotionVectorsTexture);
+float4 _CameraMotionVectorsTexture_TexelSize;
+
+inline half2 FetchMotion( const half2 aUV )
+{
+	return SAMPLE_TEXTURE2D( _CameraMotionVectorsTexture, sampler_CameraMotionVectorsTexture, UnityStereoTransformScreenSpaceTex( aUV ) ).rg;
+}
+
+
+TEXTURE2D_SAMPLER2D( _AO_CurrMotionIntensity, sampler_AO_CurrMotionIntensity );
+float4	_AO_CurrMotionIntensity_TexelSize;
+
+inline half FetchMotionIntensity( const half2 aUV )
+{
+	return  SAMPLE_TEXTURE2D( _AO_CurrMotionIntensity, sampler_AO_CurrMotionIntensity, UnityStereoTransformScreenSpaceTex( aUV ) ).r;
+}
+
+
+TEXTURE2D_SAMPLER2D( _AO_CurrOcclusionDepth, sampler_AO_CurrOcclusionDepth );
+float4	_AO_CurrOcclusionDepth_TexelSize;
+
+inline half2 FetchOcclusionDepth( const half2 aUV )
+{
+	return SAMPLE_TEXTURE2D( _AO_CurrOcclusionDepth, sampler_AO_CurrOcclusionDepth, UnityStereoTransformScreenSpaceTex( aUV ) ).rg;
+}
+
+
+TEXTURE2D_SAMPLER2D( _CameraDepthTexture, sampler_CameraDepthTexture );
+half4	_CameraDepthTexture_TexelSize;
+//TEXTURE2D_ARRAY_FLOAT(_CameraDepthTexture); SAMPLER(sampler_CameraDepthTexture);
+
+inline half SampleDepth0( const half2 aScreenPos )
+{
+	//return (aScreenPos).xxxx;
+	return SAMPLE_TEXTURE2D( _CameraDepthTexture, sampler_CameraDepthTexture, aScreenPos );
+    //return SampleSceneDepth(UnityStereoTransformScreenSpaceTex(uv)).r;
+	//return SAMPLE_DEPTH_TEXTURE_LOD( _CameraDepthTexture, sampler_CameraDepthTexture, UnityStereoTransformScreenSpaceTex( aScreenPos ), 0 );
+}
+
+TEXTURE2D_SAMPLER2D( _AO_SourceDepthMipmap, sampler_AO_SourceDepthMipmap );
+half4		_AO_SourceDepthMipmap_TexelSize;
+
+inline half SampleDepth( const half2 aScreenPos, half aLOD )
+{
+	return SAMPLE_TEXTURE2D_LOD( _AO_SourceDepthMipmap, sampler_AO_SourceDepthMipmap, UnityStereoTransformScreenSpaceTex( aScreenPos ), aLOD ).r;
+}
+
+
+// This is a dummy function, so the build will pass in the GTAO.cginc
+// on PostProcessingStack, GTAO is using only normals from DepthBuffer ( None option )
+inline half4 FetchDepthNormals( const half2 aScreenPos )
+{
+	return half4( (0).xxxx );
+}
+
+
+TEXTURE2D_SAMPLER2D( _GBufferTexture1, sampler_GBufferTexture1 );
+
+inline half4 FetchGBufferNormals( const half2 aScreenPos )
+{
+	return SAMPLE_TEXTURE2D( _GBufferTexture1, sampler_GBufferTexture1, UnityStereoTransformScreenSpaceTex( aScreenPos * _ScreenToTargetScale.xy ) );
+}
+
+
+half2 Unpack888ToFloat2( half3 x )
+{
+	uint3 i = (uint3)( x * 255.0 );
+	// 8 bit in lo, 4 bit in hi
+	uint hi = i.z >> 4;
+	uint lo = i.z & 15;
+	uint2 cb = i.xy | uint2( lo << 8, hi << 8 );
+
+	return cb / 4095.0;
+}
+
+
+half3 UnpackNormalOctQuadEncode( half2 f )
+{
+	half3 n = half3( f.x, f.y, 1.0 - abs( f.x ) - abs( f.y ) );
+	half t = max( -n.z, 0.0 );
+	n.xy += ( n.xy >= 0.0 ) ? -t.xx : t.xx;
+
+	return normalize( n );
+}
+
+inline half3 FetchGBufferNormalWS( const half2 aScreenPos, const bool aIsGBufferOctaEncoded  )
+{
+	// HDSRP only uses OctaEncoded normals
+	float4 normalBuffer = FetchGBufferNormals( aScreenPos );
+	float2 octNormalWS = Unpack888ToFloat2( normalBuffer.rgb );
+	float3 nWS = UnpackNormalOctQuadEncode( octNormalWS * 2.0 - 1.0 );
+
+	return nWS;
+}
+
+
+TEXTURE2D_SAMPLER2D( _AO_TemporalAccumm, sampler_AO_TemporalAccumm );
+float4	_AO_TemporalAccumm_TexelSize;
+
+inline half4 FetchTemporal( const half2 aScreenPos )
+{
+	return SAMPLE_TEXTURE2D( _AO_TemporalAccumm, sampler_AO_TemporalAccumm, UnityStereoTransformScreenSpaceTex( aScreenPos ) );
+}
+
+TEXTURE2D_SAMPLER2D( _AO_CurrDepthSource, sampler_AO_CurrDepthSource );
+half4		_AO_CurrDepthSource_TexelSize;
+
+inline half FetchCurrDepthSource( const half2 aScreenPos )
+{
+	return SAMPLE_TEXTURE2D( _AO_CurrDepthSource, sampler_AO_CurrDepthSource, UnityStereoTransformScreenSpaceTex( aScreenPos ) ).r;
+}
+
+
+inline float2 EncodeFloatRG( float v )
+{
+	float2 kEncodeMul = float2(1.0, 255.0);
+	float kEncodeBit = 1.0/255.0;
+	float2 enc = kEncodeMul * v;
+	enc = frac (enc);
+	enc.x -= enc.y * kEncodeBit;
+	return enc;
+}
+
+inline float DecodeFloatRG( float2 enc )
+{
+	float2 kDecodeDot = float2(1.0, 1/255.0);
+	return dot( enc, kDecodeDot );
+}
+
+
+#include "../../Resources/CommonFunctions.cginc"
+
+
+v2f_out vert( appdata v )
+{
+	v2f_out o;
+	UNITY_SETUP_INSTANCE_ID( v );
+	UNITY_TRANSFER_INSTANCE_ID( v, o );
+	UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO( o );
+
+	o.pos = float4( v.vertex.xy, 0.0, 1.0 );
+	o.uv = TransformTriangleVertexToUV( v.vertex.xy );
+
+#if UNITY_UV_STARTS_AT_TOP
+	o.uv = o.uv * float2( 1.0, -1.0 ) + float2( 0.0, 1.0 );
+#endif
+
+	return o;
+}
+
+
+#endif

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/SRP/Common.hlsl.meta
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/SRP/Common.hlsl.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: cb7ccebfcc24a234d94ae04118fb1d1a
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/SRP/OcclusionPostProcessing.shader
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/SRP/OcclusionPostProcessing.shader
@@ -1,0 +1,96 @@
+// Amplify Occlusion 2 - Robust Ambient Occlusion for Unity
+// Copyright (c) Amplify Creations, Lda <info@amplify.pt>
+
+Shader "Hidden/Amplify Occlusion/OcclusionPostProcessing"
+{
+	HLSLINCLUDE
+		#pragma vertex vert
+		#pragma fragment frag
+		#pragma target 3.0
+		#pragma exclude_renderers gles d3d11_9x n3ds
+
+		#include "Common.hlsl"
+		#include "../../Resources/GTAO.cginc"
+		#include "../../Resources/OcclusionFunctions.cginc"
+		#include "../../Resources/TemporalFilter.cginc"
+	ENDHLSL
+
+	SubShader
+	{
+		ZTest Always
+		Cull Off
+		ZWrite Off
+
+		// 0-3 => FULL OCCLUSION - LOW QUALITY                    directionCount / sampleCount
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, false, 2, 4, NORMALS_NONE ); } ENDHLSL }
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, false, 2, 4, NORMALS_CAMERA ); } ENDHLSL }
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, false, 2, 4, NORMALS_GBUFFER ); } ENDHLSL }
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, false, 2, 4, NORMALS_GBUFFER_OCTA_ENCODED ); } ENDHLSL }
+
+		// 04-07 => FULL OCCLUSION / MEDIUM QUALITY
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, false, 2, 6, NORMALS_NONE ); } ENDHLSL }
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, false, 2, 6, NORMALS_CAMERA ); } ENDHLSL }
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, false, 2, 6, NORMALS_GBUFFER ); } ENDHLSL }
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, false, 2, 6, NORMALS_GBUFFER_OCTA_ENCODED ); } ENDHLSL }
+
+		// 08-11 => FULL OCCLUSION - HIGH QUALITY
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, false, 3, 8, NORMALS_NONE ); } ENDHLSL }
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, false, 3, 8, NORMALS_CAMERA ); } ENDHLSL }
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, false, 3, 8, NORMALS_GBUFFER ); } ENDHLSL }
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, false, 3, 8, NORMALS_GBUFFER_OCTA_ENCODED ); } ENDHLSL }
+
+		// 12-15 => FULL OCCLUSION / VERYHIGH QUALITY
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, false, 4, 10, NORMALS_NONE ); } ENDHLSL }
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, false, 4, 10, NORMALS_CAMERA ); } ENDHLSL }
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, false, 4, 10, NORMALS_GBUFFER ); } ENDHLSL }
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, false, 4, 10, NORMALS_GBUFFER_OCTA_ENCODED ); } ENDHLSL }
+
+
+
+
+		// 16-19 => FULL OCCLUSION - LOW QUALITY                    directionCount / sampleCount
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, true, 2, 4, NORMALS_NONE ); } ENDHLSL }
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, true, 2, 4, NORMALS_CAMERA ); } ENDHLSL }
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, true, 2, 4, NORMALS_GBUFFER ); } ENDHLSL }
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, true, 2, 4, NORMALS_GBUFFER_OCTA_ENCODED ); } ENDHLSL }
+
+		// 20-23 => FULL OCCLUSION / MEDIUM QUALITY
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, true, 2, 6, NORMALS_NONE ); } ENDHLSL }
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, true, 2, 6, NORMALS_CAMERA ); } ENDHLSL }
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, true, 2, 6, NORMALS_GBUFFER ); } ENDHLSL }
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, true, 2, 6, NORMALS_GBUFFER_OCTA_ENCODED ); } ENDHLSL }
+
+		// 24-27 => FULL OCCLUSION - HIGH QUALITY
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, true, 3, 8, NORMALS_NONE ); } ENDHLSL }
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, true, 3, 8, NORMALS_CAMERA ); } ENDHLSL }
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, true, 3, 8, NORMALS_GBUFFER ); } ENDHLSL }
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, true, 3, 8, NORMALS_GBUFFER_OCTA_ENCODED ); } ENDHLSL }
+
+		// 28-31 => FULL OCCLUSION / VERYHIGH QUALITY
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, true, 4, 10, NORMALS_NONE ); } ENDHLSL }
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, true, 4, 10, NORMALS_CAMERA ); } ENDHLSL }
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, true, 4, 10, NORMALS_GBUFFER ); } ENDHLSL }
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return GTAO( IN, true, 4, 10, NORMALS_GBUFFER_OCTA_ENCODED ); } ENDHLSL }
+
+
+		// 32 => CombineDownsampledOcclusionDepth
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return CombineDownsampledOcclusionDepth( IN );	} ENDHLSL	}
+
+		// 33 => Neighbor Motion Intensity
+		Pass { HLSLPROGRAM half2 frag( v2f_in IN ) : SV_Target { return NeighborMotionIntensity( IN ); } ENDHLSL }
+
+		// 34 => ClearTemporal
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return ClearTemporal( IN ); } ENDHLSL }
+
+		// 35 => ScaleDownCloserDepthEven
+		Pass { HLSLPROGRAM float frag( v2f_in IN ) : SV_Target { return ScaleDownCloserDepthEven( IN ); } ENDHLSL }
+		
+		// 36 => ScaleDownCloserDepthEven_CameraDepthTexture
+		Pass { HLSLPROGRAM float frag( v2f_in IN ) : SV_Target { return ScaleDownCloserDepthEven_CameraDepthTexture( IN ); } ENDHLSL }
+
+		// 37 => Temporal
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return Temporal( IN, false ); } ENDHLSL }
+		Pass { HLSLPROGRAM half4 frag( v2f_in IN ) : SV_Target { return Temporal( IN, true ); } ENDHLSL }
+	}
+}
+

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/SRP/OcclusionPostProcessing.shader.meta
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/SRP/OcclusionPostProcessing.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 32ada649449f09049bfaede1ca478a25
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/TemporalFilter.cginc
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/TemporalFilter.cginc
@@ -1,0 +1,594 @@
+// Amplify Occlusion 2 - Robust Ambient Occlusion for Unity
+// Copyright (c) Amplify Creations, Lda <info@amplify.pt>
+
+#ifndef AMPLIFY_AO_TEMPORALFILTER
+#define AMPLIFY_AO_TEMPORALFILTER
+
+
+//#define NEIGHBOR_SAMPLE_4TAP
+#define NEIGHBOR_SAMPLE_4TAP_CROSS
+//#define NEIGHBOR_SAMPLE_8TAP
+
+#define CLAMP_MINMAX
+
+#define DEPTH_WEIGHTING ( _AO_TemporalMotionSensibility * 1000 + 200.0 )
+#define DEPTH_WEIGHTING_OFFSET ( 0.10 )
+
+//#define MINMAX_DEVIATION
+#define VARIANCE_CLIPPING ( 7.0 )
+#define VARIANCE_CLIPPING_OFFSET ( 1.5 )
+
+#define SIGMA_SCALE_MAX ( 0.75 )
+#define SIGMA_SCALE_MIN ( 1.00 )
+
+#define MOTION_ATTEN
+#define DISOCCLUSION_ATTEN
+#define DISOCCLUSION_NEIGHBOR
+#define OUTOFRANGE_COMPENSATION
+#define OUTOFRANGE_ENDCOMPENSATION
+
+
+float4x4	_AO_InvViewProjMatrixLeft;
+float4x4	_AO_PrevViewProjMatrixLeft;
+float4x4	_AO_PrevInvViewProjMatrixLeft;
+
+float4x4	_AO_InvViewProjMatrixRight;
+float4x4	_AO_PrevViewProjMatrixRight;
+float4x4	_AO_PrevInvViewProjMatrixRight;
+
+float		_AO_TemporalCurveAdj;
+
+inline half CalcDisocclusion( const half aDepth, const half aPrevDepth, const half aSensibility )
+{
+	const half depthDiff = abs( aDepth - aPrevDepth );
+	return saturate( aSensibility * depthDiff - 0.02 );
+}
+
+
+inline half2 FetchPrevAO_Depth( const float2 aUV )
+{
+	float2 uv = aUV;
+/*#if UNITY_UV_STARTS_AT_TOP
+	uv.y = ( _ProjectionParams.x > 0 ) ? 1 - aUV.y : aUV.y;
+#endif*/
+	const half4 temporalAccummEnc = FetchTemporal( uv );
+
+	return half2( DecAO( temporalAccummEnc.x ), DecDepth( temporalAccummEnc.yz ) );
+}
+
+
+inline half3 FetchPrevAO_Depth_N( const float2 aUV )
+{
+	float2 uv = aUV;
+#if UNITY_UV_STARTS_AT_TOP
+	uv.y = ( _ProjectionParams.x > 0 ) ? 1 - aUV.y : aUV.y;
+#endif
+	const half4 temporalAccummEnc = FetchTemporal( uv );
+
+	return half3( DecAO( temporalAccummEnc.x ), DecDepth( temporalAccummEnc.yz ), temporalAccummEnc.w );
+}
+
+
+inline half FetchPrevN( const float2 aUV )
+{
+	float2 uv = aUV;
+#if UNITY_UV_STARTS_AT_TOP
+	uv.y = ( _ProjectionParams.x > 0 ) ? 1 - aUV.y : aUV.y;
+#endif
+	const half4 temporalAccummEnc = FetchTemporal( uv );
+
+	return temporalAccummEnc.w;
+}
+
+
+#if defined( VARIANCE_CLIPPING )
+
+inline half ComputeSigma( const half aInSigma, const half aMotionNeighborIntensity, const half aDisocclusion, const half aPrevN )
+{
+	// "Larger gammas produced more temporally stable results at the cost of increased ghosting." - msalvi_temporal_supersampling.pdf - page 24
+	half outSigma = VARIANCE_CLIPPING * ( VARIANCE_CLIPPING_OFFSET - _AO_TemporalMotionSensibility ) * aInSigma;
+
+	#if defined( MOTION_ATTEN )
+	outSigma = outSigma * ( 1.0 - aMotionNeighborIntensity );
+	#endif
+
+	#if defined( DISOCCLUSION_ATTEN )
+	outSigma = outSigma * ( 1.0 - aDisocclusion );
+	#endif
+
+	outSigma = outSigma * aPrevN;
+
+	return max( outSigma, 0.0 );
+}
+
+#else
+
+#if defined( MINMAX_DEVIATION )
+
+inline half ComputeDeviation( const half aMotionNeighborIntensity, const half aDisocclusion, const half aPrevN, const half aOutOfRange )
+{
+	half outDeviation = 0.15 * ( ( 1.25 ) - _AO_TemporalMotionSensibility ) + aOutOfRange;
+
+	#if defined( MOTION_ATTEN )
+	outDeviation = outDeviation * ( 1.0 - aMotionNeighborIntensity );
+	#endif
+
+	#if defined( DISOCCLUSION_ATTEN )
+	outDeviation = outDeviation * ( 1.0 - aDisocclusion );
+	#endif
+
+	outDeviation = outDeviation * aPrevN;
+
+	return saturate( outDeviation );
+}
+
+#endif
+
+#endif
+
+
+#if defined( DISOCCLUSION_NEIGHBOR )
+
+inline half FetchNeighborPrevN( const half2 aUV, const half aRadiusPixels )
+{
+	half noiseSpatialOffsets, noiseSpatialDirections;
+	GetSpatialDirections_Offsets_JimenezNoise( aUV, _AO_TemporalAccumm_TexelSize.zw, noiseSpatialOffsets, noiseSpatialDirections );
+
+	const half angle = ( noiseSpatialDirections + _AO_TemporalDirections ) * UNITY_PI;
+	const half2 cos_sin = half2( cos( angle ), sin( angle ) );
+	const half2 xy = ( aRadiusPixels * noiseSpatialOffsets + 2.0 ).xx * cos_sin;
+
+	const half dL = FetchPrevN( half2( -xy.x, -xy.y ) * _AO_TemporalAccumm_TexelSize.xy + aUV );
+	const half dR = FetchPrevN( half2( +xy.x, +xy.y ) * _AO_TemporalAccumm_TexelSize.xy + aUV );
+
+	return min( dL, dR );
+}
+
+
+half NeighborPrevN( const float2 aScreenPos, const half aLinearEyeDepth )
+{
+	const half radius = lerp( _AO_Radius, _AO_FadeValues.y, ComputeDistanceFade( aLinearEyeDepth ) );
+	const half radiusToScreen = 0.50 * radius * _AO_HalfProjScale;
+	const half screenRadius = max( min( ( radiusToScreen / aLinearEyeDepth ), PIXEL_RADIUS_LIMIT ), 2 );
+
+	return FetchNeighborPrevN( aScreenPos, screenRadius );
+}
+
+#endif
+void GetTemporalFilter( const float2 aScreenPos,
+						const half aCurrAO,
+						const half aSampledDepth,
+						const half aLinearEyeDepth,
+						const half aLinear01Depth,
+						const bool aUseMotionVectors,
+						out half outAO,
+						out half outNewN,
+						out half out_temporal_AO )
+{
+
+	float2 reproj_screenPos = (0).xx;
+
+	half2 mv = (0).xx;
+
+	half motionNeighborIntensity = 0;
+
+	if( aUseMotionVectors == false )
+	{
+		half depth01 = aSampledDepth;
+
+		#if defined(UNITY_REVERSED_Z)
+		depth01 = 1.0 - depth01;
+		#endif
+
+		#if defined( SHADER_API_OPENGL ) || defined( SHADER_API_GLES ) || defined( SHADER_API_GLES3 ) || defined( SHADER_API_GLCORE )
+		const float4 vpos = float4( float3( aScreenPos, depth01 ) * 2.0 - 1.0, 1.0 );
+		#else
+		const float4 vpos = float4( ( aScreenPos * 2.0 - 1.0 ), ( 1.0 - depth01 ), 1.0 );
+		#endif
+
+		#ifdef UNITY_SINGLE_PASS_STEREO
+		float4x4 invViewProjMatrix;
+
+		if ( unity_StereoEyeIndex == 0 )
+		{
+			invViewProjMatrix = _AO_InvViewProjMatrixLeft;
+		}
+		else
+		{
+			invViewProjMatrix = _AO_InvViewProjMatrixRight;
+		}
+
+		float4 wpos = mul( invViewProjMatrix, vpos );
+
+		#else
+
+		float4 wpos = mul( _AO_InvViewProjMatrixLeft, vpos );
+
+		#endif
+
+		wpos = wpos / wpos.w;
+
+		#ifdef UNITY_SINGLE_PASS_STEREO
+		float4x4 prevViewProjMatrix;
+
+		if ( unity_StereoEyeIndex == 0 )
+		{
+			prevViewProjMatrix = _AO_PrevViewProjMatrixLeft;
+		}
+		else
+		{
+			prevViewProjMatrix = _AO_PrevViewProjMatrixRight;
+		}
+
+		const float4 reproj_vpos = mul( prevViewProjMatrix, wpos );
+
+		#else
+		const float4 reproj_vpos = mul( _AO_PrevViewProjMatrixLeft, wpos );
+		#endif
+
+		reproj_screenPos = ( reproj_vpos.xy / reproj_vpos.w ) * 0.5 + 0.5;
+
+		mv = aScreenPos - reproj_screenPos;
+	}
+	else
+	{
+		mv = FetchMotion( aScreenPos );
+
+		motionNeighborIntensity = FetchMotionIntensity( aScreenPos );
+
+		reproj_screenPos = aScreenPos - mv;
+	}
+
+
+	if( ( ( reproj_screenPos.x < 0.0 ) ||
+		  ( reproj_screenPos.y < 0.0 ) ||
+		  ( reproj_screenPos.x > 1.0 ) ||
+		  ( reproj_screenPos.y > 1.0 ) ) == false )
+	{
+		const half3 prev_AO_Depth_N = FetchPrevAO_Depth_N( reproj_screenPos );
+
+		const half cM = aCurrAO;
+		const half cAcc = prev_AO_Depth_N.x;
+		half prev_linear01Depth = prev_AO_Depth_N.y;
+		half prev_sampledDepth = Linear01ToSampledDepth( prev_linear01Depth );
+		half prev_N = prev_AO_Depth_N.z;
+
+		const half mvLenght = length( mv );
+
+		half disocclusion = CalcDisocclusion( aSampledDepth, prev_sampledDepth, ( _AO_TemporalMotionSensibility * 20.0 + 1.0 ) * aLinearEyeDepth );
+
+		#if defined( DISOCCLUSION_NEIGHBOR )
+		if( aUseMotionVectors == false )
+		{
+			prev_N = lerp( prev_N, min( prev_N , NeighborPrevN( aScreenPos, aLinearEyeDepth ) ), saturate( _AO_TemporalMotionSensibility * 0.50 + 0.50 ) );
+		}
+		#endif
+
+		#if defined( NEIGHBOR_SAMPLE_4TAP )
+
+		// "variable distance to 4 sample points, decided per-pixel"
+		// "higher velocity ⇒ closer to center texel (strict on motion)" - slide 26
+		// "sample offset 0.5-0.666 from texel center" - slide 26
+		const half vd = lerp( 0.71, 0.50, mvLenght );
+
+		half2 cTL = FetchOcclusionDepth( half2( -vd, -vd ) * _AO_CurrOcclusionDepth_TexelSize.xy + aScreenPos );
+		half2 cTR = FetchOcclusionDepth( half2( +vd, -vd ) * _AO_CurrOcclusionDepth_TexelSize.xy + aScreenPos );
+		half2 cBL = FetchOcclusionDepth( half2( -vd, +vd ) * _AO_CurrOcclusionDepth_TexelSize.xy + aScreenPos );
+		half2 cBR = FetchOcclusionDepth( half2( +vd, +vd ) * _AO_CurrOcclusionDepth_TexelSize.xy + aScreenPos );
+
+		half4 o0123 = half4( cTL.x, cTR.x, cBL.x, cBR.x );
+
+		#if defined( DEPTH_WEIGHTING )
+		const half4 d0123 = half4( cTL.y, cTR.y, cBL.y, cBR.y );
+		half4 depthWeight0123 = saturate( 1.0 / ( abs( Linear01ToSampledDepth( d0123 * ONE_OVER_DEPTH_SCALE ) - ( aSampledDepth ).xxxx ) * DEPTH_WEIGHTING + DEPTH_WEIGHTING_OFFSET ) );
+		depthWeight0123 = depthWeight0123 * depthWeight0123;
+		const half depthVariance = dot( (1).xxxx, depthWeight0123 ) * 0.25;
+		o0123 = lerp( (cM).xxxx, o0123, depthWeight0123 );
+		cTL.x = o0123.x;
+		cTR.x = o0123.y;
+		cBL.x = o0123.z;
+		cBR.x = o0123.w;
+		#endif
+
+		#if defined( VARIANCE_CLIPPING )
+		// Salvi 2016 - msalvi_temporal_supersampling.pdf - page 23
+		const half m1 = dot( (1).xxxx, o0123 );
+
+		const half4 o0123_squared = o0123 * o0123;
+
+		const half m2 = dot( (1).xxxx, o0123_squared );
+
+		const half oneOverN = 1.0 / 4.0;
+		const half mu = m1 * oneOverN;
+		float Sigma = sqrt( max( m2 * oneOverN - mu * mu, 0.0 ) );
+
+		Sigma = ComputeSigma( Sigma, motionNeighborIntensity, disocclusion, prev_N );
+
+		half cMin = max( mu - Sigma * SIGMA_SCALE_MIN, 0.0 );
+		half cMax = min( mu + Sigma * SIGMA_SCALE_MAX, 1.0 );
+		#else
+		half cMax = max( aCurrAO, max( cTL.x, max( cTR.x, max( cBL.x, cBR.x ) ) ) );
+		half cMin = min( aCurrAO, min( cTL.x, min( cTR.x, min( cBL.x, cBR.x ) ) ) );
+		#endif
+
+
+		const half2 cAvrg = ( cTL + cTR + cBL + cBR ) * (0.25).xx;
+		#else
+		#if defined( NEIGHBOR_SAMPLE_4TAP_CROSS )
+		const half vd = 1.0;
+		half2 cT = FetchOcclusionDepth( half2(   0, -vd ) * _AO_CurrOcclusionDepth_TexelSize.xy + aScreenPos );
+		half2 cL = FetchOcclusionDepth( half2( -vd,   0 ) * _AO_CurrOcclusionDepth_TexelSize.xy + aScreenPos );
+		half2 cR = FetchOcclusionDepth( half2( +vd,   0 ) * _AO_CurrOcclusionDepth_TexelSize.xy + aScreenPos );
+		half2 cB = FetchOcclusionDepth( half2(   0, +vd ) * _AO_CurrOcclusionDepth_TexelSize.xy + aScreenPos );
+
+		half4 o0123 = half4( cT.x, cL.x, cR.x, cB.x );
+
+		#if defined( DEPTH_WEIGHTING )
+		const half4 d0123 = half4( cT.y, cL.y, cR.y, cB.y );
+		half4 depthWeight0123 = saturate( 1.0 / ( abs( Linear01ToSampledDepth( d0123 * ONE_OVER_DEPTH_SCALE ) - ( aSampledDepth ).xxxx ) * DEPTH_WEIGHTING + DEPTH_WEIGHTING_OFFSET ) );
+		depthWeight0123 = depthWeight0123 * depthWeight0123;
+		const half depthVariance = dot( (1).xxxx, depthWeight0123 ) * 0.25;
+		o0123 = lerp( (cM).xxxx, o0123, depthWeight0123 );
+		cT.x = o0123.x;
+		cL.x = o0123.y;
+		cR.x = o0123.z;
+		cB.x = o0123.w;
+		#endif
+
+		#if defined( VARIANCE_CLIPPING )
+		// Salvi 2016 - msalvi_temporal_supersampling.pdf - page 23
+		const half m1 = dot( (1).xxxx, o0123 );
+
+		const half4 o0123_squared = o0123 * o0123;
+
+		const half m2 = dot( (1).xxxx, o0123_squared );
+
+		const half oneOverN = 1.0 / 4.0;
+		const half mu = m1 * oneOverN;
+		float Sigma = sqrt( max( m2 * oneOverN - mu * mu, 0.0 ) );
+
+		Sigma = ComputeSigma( Sigma, motionNeighborIntensity, disocclusion, prev_N );
+
+		half cMin = max( mu - Sigma * SIGMA_SCALE_MIN, 0.0 );
+		half cMax = min( mu + Sigma * SIGMA_SCALE_MAX, 1.0 );
+		#else
+		half cMax = max( aCurrAO, max( cT.x, max( cL.x, max( cR.x, cB.x ) ) ) );
+		half cMin = min( aCurrAO, min( cT.x, min( cL.x, min( cR.x, cB.x ) ) ) );
+		#endif
+
+
+		const half2 cAvrg = ( cT + cL + cR + cB ) * (0.25).xx;
+		#else
+		#if defined( NEIGHBOR_SAMPLE_8TAP )
+		const half vd = 1.0;
+		half2 cT = FetchOcclusionDepth( half2(   0, -vd ) * _AO_CurrOcclusionDepth_TexelSize.xy + aScreenPos );
+		half2 cL = FetchOcclusionDepth( half2( -vd,   0 ) * _AO_CurrOcclusionDepth_TexelSize.xy + aScreenPos );
+		half2 cR = FetchOcclusionDepth( half2( +vd,   0 ) * _AO_CurrOcclusionDepth_TexelSize.xy + aScreenPos );
+		half2 cB = FetchOcclusionDepth( half2(   0, +vd ) * _AO_CurrOcclusionDepth_TexelSize.xy + aScreenPos );
+
+		const half dd = 1.55;
+		half2 cTL = FetchOcclusionDepth( half2( -dd, -dd ) * _AO_CurrOcclusionDepth_TexelSize.xy + aScreenPos );
+		half2 cTR = FetchOcclusionDepth( half2( +dd, -dd ) * _AO_CurrOcclusionDepth_TexelSize.xy + aScreenPos );
+		half2 cBL = FetchOcclusionDepth( half2( -dd, +dd ) * _AO_CurrOcclusionDepth_TexelSize.xy + aScreenPos );
+		half2 cBR = FetchOcclusionDepth( half2( +dd, +dd ) * _AO_CurrOcclusionDepth_TexelSize.xy + aScreenPos );
+
+		half4 o0123 = half4( cT.x, cL.x, cR.x, cB.x );
+		half4 o4567 = half4( cTL.x, cTR.x, cBL.x, cBR.x );
+
+		#if defined( DEPTH_WEIGHTING )
+		const half4 d0123 = half4( cT.y, cL.y, cR.y, cB.y );
+		half4 depthWeight0123 = saturate( 1.0 / ( abs( Linear01ToSampledDepth( d0123 * ONE_OVER_DEPTH_SCALE ) - ( aSampledDepth ).xxxx ) * DEPTH_WEIGHTING + DEPTH_WEIGHTING_OFFSET ) );
+		depthWeight0123 = depthWeight0123 * depthWeight0123;
+		o0123 = lerp( (cM).xxxx, o0123, depthWeight0123 );
+		cT.x = o0123.x;
+		cL.x = o0123.y;
+		cR.x = o0123.z;
+		cB.x = o0123.w;
+
+		const half4 d4567 = half4( cTL.y, cTR.y, cBL.y, cBR.y );
+		half4 depthWeight4567 = saturate( 1.0 / ( abs( Linear01ToSampledDepth( d4567 * ONE_OVER_DEPTH_SCALE ) - ( aSampledDepth ).xxxx ) * DEPTH_WEIGHTING + DEPTH_WEIGHTING_OFFSET ) );
+		depthWeight4567 = depthWeight4567 * depthWeight4567;
+		o4567 = lerp( (cM).xxxx, o4567, depthWeight4567 );
+		cTL.x = o4567.x;
+		cTR.x = o4567.y;
+		cBL.x = o4567.z;
+		cBR.x = o4567.w;
+
+		const half depthVariance = ( dot( (1).xxxx, depthWeight0123 ) + dot( (1).xxxx, depthWeight4567 ) ) * 0.125;
+		#endif
+
+		#if defined( VARIANCE_CLIPPING )
+		// Salvi 2016 - msalvi_temporal_supersampling.pdf - page 23
+		const half m1 = dot( (1).xxxx, o0123 ) + dot( (1).xxxx, o4567 );
+
+		const half4 o0123_squared = o0123 * o0123;
+		const half4 o4567_squared = o4567 * o4567;
+
+		const half m2 = dot( (1).xxxx, o0123_squared ) + dot( (1).xxxx, o4567_squared );
+
+		const half oneOverN = 1.0 / 8.0;
+		const half mu = m1 * oneOverN;
+		float Sigma = sqrt( max( m2 * oneOverN - mu * mu, 0.0 ) );
+
+		Sigma = ComputeSigma( Sigma, motionNeighborIntensity, disocclusion, prev_N );
+
+		half cMin = max( mu - Sigma * SIGMA_SCALE_MIN, 0.0 );
+		half cMax = min( mu + Sigma * SIGMA_SCALE_MAX, 1.0 );
+		#else
+		half cMax = max( aCurrAO, max( cTL.x, max( cTR.x, max( cBL.x, max( cBR.x, max( cT.x, max( cL.x, max( cR.x, cB.x ) ) ) ) ) ) ) );
+		half cMin = min( aCurrAO, min( cTL.x, min( cTR.x, min( cBL.x, min( cBR.x, min( cT.x, min( cL.x, min( cR.x, cB.x ) ) ) ) ) ) ) );
+		#endif
+
+		const half2 cAvrg = ( cT + cL + cR + cB + cTL + cTR + cBL + cBR ) * (0.125).xx;
+		#endif
+		#endif
+		#endif
+
+		#if defined( OUTOFRANGE_COMPENSATION )
+
+		#if defined( VARIANCE_CLIPPING )
+		half accOutOfRange = saturate( ( max( abs( cAcc - cMin.x ), abs( cAcc - cMax.x ) ) * 3.5 - 0.03 ) );
+		#else
+		const half accOutOfRange = saturate( ( max( abs( cAcc - cMin.x ), abs( cAcc - cMax.x ) ) - 0.01 ) );
+		#endif
+
+		#else
+		const half accOutOfRange = 0.0;
+		#endif
+
+		#if defined( MINMAX_DEVIATION )
+		const half deviation = ComputeDeviation( motionNeighborIntensity, disocclusion, prev_N, accOutOfRange );
+		cMax.x = min( cMax.x + deviation * SIGMA_SCALE_MAX, 1.0 );
+		cMin.x = max( cMin.x - deviation * SIGMA_SCALE_MIN, 0.0 );
+		#endif
+
+		#if defined( CLAMP_MINMAX )
+		half clampedAcc = clamp( cAcc, cMin.x, cMax.x );
+
+		#if defined( VARIANCE_CLIPPING )
+		#if defined( OUTOFRANGE_COMPENSATION )
+		clampedAcc = lerp( clampedAcc, cAcc, accOutOfRange );
+		#endif
+		#endif
+
+		#else
+		half clampedAcc = cM;
+		#endif
+
+		half newN = saturate( prev_N + ( 1.0 / 6.0 ) );
+		const half oneMinusDisocclusion = ( 1.0 - disocclusion );
+		newN = min( newN, oneMinusDisocclusion * oneMinusDisocclusion );
+
+		if( aUseMotionVectors == true )
+		{
+			newN = min( newN, 1.0 - motionNeighborIntensity );
+		}
+
+		#if defined( MOTION_ATTEN )
+		const half2 mvToPixels = mv * _AO_CurrOcclusionDepth_TexelSize.zw;
+		const half mvLenghtPixelsSquared = dot( mvToPixels, mvToPixels );
+		const half mvWeighting = saturate( mvLenghtPixelsSquared * 0.0005 * _AO_TemporalMotionSensibility );
+		const half mvMaxMotion = saturate( max( motionNeighborIntensity, mvWeighting ) );
+		const half mvIntensity = ( 1.0 - mvMaxMotion );
+
+		const half finalLerp = min( saturate( prev_N * mvIntensity - disocclusion ), 0.96 );
+		#else
+		const half finalLerp = min( saturate( prev_N - disocclusion ), 0.96 );
+		#endif
+
+		half new_ao = lerp( cM, lerp( clampedAcc, cAcc, _AO_TemporalCurveAdj ), finalLerp );
+
+		#if defined( OUTOFRANGE_ENDCOMPENSATION )
+		half outOfRangeCompensation = saturate( abs( new_ao - cAcc ) * ( 0.3 + _AO_TemporalMotionSensibility ) );
+
+		new_ao = lerp( new_ao, cM, outOfRangeCompensation );
+		newN = saturate( newN - min( outOfRangeCompensation * outOfRangeCompensation, 1.0 / 7.0 ) );
+		#endif
+
+		out_temporal_AO = new_ao;
+		outAO = new_ao;
+		outNewN = newN;
+	}
+	else
+	{
+		out_temporal_AO = aCurrAO;
+		outAO = aCurrAO;
+		outNewN = 0.0;
+	}
+}
+
+
+half4 TemporalFilter( const half2 aScreenPos, const half aOcclusion, const half aSampledDepth, const half aLinearEyeDepth, const half aLinear01Depth, const bool aUseMotionVectors, out half outOcclusion )
+{
+	half out_ao, out_newN, out_temporal_ao;
+
+	GetTemporalFilter(	aScreenPos,
+						aOcclusion,
+						aSampledDepth,
+						aLinearEyeDepth,
+						aLinear01Depth,
+						aUseMotionVectors,
+						out_ao,
+						out_newN,
+						out_temporal_ao );
+
+	outOcclusion = out_ao;
+
+	return half4( EncAO( out_temporal_ao ), EncDepth( aLinear01Depth ), out_newN );
+}
+
+
+half4 Temporal( v2f_in IN, const bool aUseMotionVectors )
+{
+	UNITY_SETUP_INSTANCE_ID( IN );
+	UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX( IN );
+
+	const float2 screenPos = IN.uv.xy;
+
+	const half2 occlusionDepth = FetchOcclusionDepth( screenPos );
+
+	if( occlusionDepth.y < HALF_MAX )
+	{
+		const half linear01Depth = occlusionDepth.y * ONE_OVER_DEPTH_SCALE;
+		const half sampledDepth = Linear01ToSampledDepth( linear01Depth );
+		const half linearEyeDepth = occlusionDepth.y * _AO_BufDepthToLinearEye;
+
+		half dummy_occlusion;
+		return TemporalFilter( screenPos, occlusionDepth.x, sampledDepth, linearEyeDepth, linear01Depth, aUseMotionVectors, dummy_occlusion );
+	}
+	else
+	{
+		return half4( (1).xxxx );
+	}
+}
+
+
+inline half2 ComputeCombineDownsampledOcclusionFromTemporal( const half2 aScreenPos, const half aDepthSample )
+{
+	const half referenceDepth = LinearEyeDepth( aDepthSample );
+
+	const half intensity = lerp( _AO_Levels.a, _AO_FadeValues.x, ComputeDistanceFade( referenceDepth ) );
+
+	//UNITY_BRANCH
+	#if defined(UNITY_REVERSED_Z)
+	if( ( aDepthSample <= DEPTH_EPSILON ) || ( intensity < INTENSITY_THRESHOLD ) )
+	#else
+	if( ( aDepthSample >= ( 1.0 - DEPTH_EPSILON ) ) || ( intensity < INTENSITY_THRESHOLD ) )
+	#endif
+	{
+		return half2( 1.0, HALF_MAX );
+	}
+
+	const half2 screenPosPixels = aScreenPos * _AO_TemporalAccumm_TexelSize.zw;
+	const half2 screenPosPixelsFloor = floor( screenPosPixels );
+	const half2 screenPosPixelsDelta = screenPosPixels - screenPosPixelsFloor;
+
+	const half2 sPosAdjusted = screenPosPixelsFloor * _AO_TemporalAccumm_TexelSize.xy + half2( 0.5, 0.5 ) * _AO_TemporalAccumm_TexelSize.xy;
+	const half s = ( screenPosPixelsDelta.y < 0.5 )?-1.0:1.0;
+
+	half2 odC = FetchPrevAO_Depth( sPosAdjusted );
+
+	half2 odL = FetchPrevAO_Depth( sPosAdjusted + half2( -1.0, 0.0 ) * _AO_TemporalAccumm_TexelSize.xy );
+	half2 odR = FetchPrevAO_Depth( sPosAdjusted + half2( +1.0, 0.0 ) * _AO_TemporalAccumm_TexelSize.xy );
+	half2 odM = FetchPrevAO_Depth( sPosAdjusted + half2(  0.0,   s ) * _AO_TemporalAccumm_TexelSize.xy );
+
+	const half4 o0123 = half4( odC.x, odL.x, odR.x, odM.x );
+	const half4 d0123 = half4( odC.y, odL.y, odR.y, odM.y );
+
+	half4 depthWeight0123 = saturate( 1.0 / ( abs( Linear01ToSampledDepth( d0123 ) - ( aDepthSample ).xxxx ) * 32768 + 0.95 ) );
+
+	const half4 pixelDeltaWeight = half4( screenPosPixelsDelta.x * screenPosPixelsDelta.y + 0.5,
+											1.0 - screenPosPixelsDelta.x,
+											screenPosPixelsDelta.x,
+											0.80 );
+
+	depthWeight0123 = depthWeight0123 * depthWeight0123 * pixelDeltaWeight;
+
+	half weightOcclusion = dot( o0123, depthWeight0123 );
+
+	const half outOcclusion = saturate( weightOcclusion / dot( ( 1 ).xxxx, depthWeight0123 ) );
+
+	return half2( outOcclusion, referenceDepth );
+}
+
+#endif

--- a/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/TemporalFilter.cginc.meta
+++ b/Assets/AmplifyOcclusion-URP/AmplifyOcclusion/Resources/TemporalFilter.cginc.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 99bb66f53a3674e6cad462ff44c28826
+timeCreated: 1522081059
+licenseType: Pro
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AmplifyOcclusion-URP/LICENSE
+++ b/Assets/AmplifyOcclusion-URP/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Neonage
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Assets/AmplifyOcclusion-URP/LICENSE.meta
+++ b/Assets/AmplifyOcclusion-URP/LICENSE.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7799d25139fb80cb6bedf22f8ca76bf1
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AmplifyOcclusion-URP/README.md
+++ b/Assets/AmplifyOcclusion-URP/README.md
@@ -1,0 +1,30 @@
+# AmplifyOcclusion-URP
+https://github.com/AmplifyCreations/AmplifyOcclusion \
+Ported in **URP 2022.2**, but might work in older versions.
+
+### Requirements
+* <b>com.unity.postprocessing</b> package installed! (uses StdLib.hlsl, I'd need to remove this dependency)
+
+### How to use
+* Add Amplify Occlusion in Volume component
+* Add Amplify Occlusion RendererFeature in URP Renderer Asset
+* Enable Depth Texture in URP Asset
+
+
+
+
+https://user-images.githubusercontent.com/29812914/209881618-3d97f67a-c720-42a1-a656-4568823ec05f.mp4
+>https://github.com/UnityTechnologies/open-project-1
+
+
+https://user-images.githubusercontent.com/29812914/209586549-285353c3-1adf-4fdc-9627-e702273841e1.mp4
+>Spider Controller in the video: https://github.com/PhilS94/Unity-Procedural-IK-Wall-Walking-Spider
+
+## Known Issues
+* Skybox is broken in 2020.3-2021.3
+* Doesn't work with Multi-Camera setup (split-screen, etc)
+* Doesn't work in scene view
+* Temporal Filtering not supported
+* GBuffer Normals not supported
+
+

--- a/Assets/AmplifyOcclusion-URP/README.md.meta
+++ b/Assets/AmplifyOcclusion-URP/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 86eb9266911642f95a0c473197898bfb
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/PlayerMouseKeyboard.meta
+++ b/Assets/Scenes/PlayerMouseKeyboard.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 700699d6f705755fa879b421d348c079
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/PlayerMouseKeyboard.unity
+++ b/Assets/Scenes/PlayerMouseKeyboard.unity
@@ -135,6 +135,7 @@ GameObject:
   - component: {fileID: 389742605}
   - component: {fileID: 389742604}
   - component: {fileID: 389742603}
+  - component: {fileID: 389742607}
   m_Layer: 0
   m_Name: Camera
   m_TagString: MainCamera
@@ -165,7 +166,7 @@ MonoBehaviour:
     m_Bits: 1
   m_VolumeTrigger: {fileID: 0}
   m_VolumeFrameworkUpdateModeOption: 2
-  m_RenderPostProcessing: 0
+  m_RenderPostProcessing: 1
   m_Antialiasing: 0
   m_AntialiasingQuality: 2
   m_StopNaN: 0
@@ -260,6 +261,23 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &389742607
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 389742602}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 172515602e62fb746b5d573b38a5fe58, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IsGlobal: 1
+  priority: 0
+  blendDistance: 0
+  weight: 1
+  sharedProfile: {fileID: 11400000, guid: 11d6b15f9bce75cd996cd3993ce49287, type: 2}
 --- !u!1001 &683323226
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/PlayerMouseKeyboard/Camera Profile.asset
+++ b/Assets/Scenes/PlayerMouseKeyboard/Camera Profile.asset
@@ -1,0 +1,98 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d7fd9488000d3734a9e00ee676215985, type: 3}
+  m_Name: Camera Profile
+  m_EditorClassIdentifier: 
+  components:
+  - {fileID: 2264512853449100066}
+--- !u!114 &2264512853449100066
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9a1a0912ccc82aa49bc9c20a5f3409b2, type: 3}
+  m_Name: AmplifyOcclusionVolume
+  m_EditorClassIdentifier: 
+  active: 1
+  ApplyMethod:
+    m_OverrideState: 1
+    m_Value: 0
+  SampleCount:
+    m_OverrideState: 1
+    m_Value: 1
+  RampTexture:
+    m_OverrideState: 0
+    m_Value: {fileID: 0}
+  Intensity:
+    m_OverrideState: 1
+    m_Value: 1
+  Tint:
+    m_OverrideState: 0
+    m_Value: {r: 0, g: 0, b: 0, a: 1}
+  Radius:
+    m_OverrideState: 1
+    m_Value: 1.3
+  PowerExponent:
+    m_OverrideState: 1
+    m_Value: 0.5
+  Bias:
+    m_OverrideState: 0
+    m_Value: 0.05
+  Thickness:
+    m_OverrideState: 1
+    m_Value: 0.5
+  Downsample:
+    m_OverrideState: 1
+    m_Value: 1
+  CacheAware:
+    m_OverrideState: 0
+    m_Value: 0
+  FadeEnabled:
+    m_OverrideState: 0
+    m_Value: 0
+  FadeStart:
+    m_OverrideState: 0
+    m_Value: 100
+  FadeLength:
+    m_OverrideState: 0
+    m_Value: 50
+  FadeToIntensity:
+    m_OverrideState: 0
+    m_Value: 0
+  FadeToTint:
+    m_OverrideState: 0
+    m_Value: {r: 0, g: 0, b: 0, a: 1}
+  FadeToRadius:
+    m_OverrideState: 0
+    m_Value: 2
+  FadeToPowerExponent:
+    m_OverrideState: 0
+    m_Value: 1
+  FadeToThickness:
+    m_OverrideState: 0
+    m_Value: 1
+  BlurEnabled:
+    m_OverrideState: 1
+    m_Value: 1
+  BlurRadius:
+    m_OverrideState: 1
+    m_Value: 2
+  BlurPasses:
+    m_OverrideState: 1
+    m_Value: 1
+  BlurSharpness:
+    m_OverrideState: 1
+    m_Value: 2.6

--- a/Assets/Scenes/PlayerMouseKeyboard/Camera Profile.asset.meta
+++ b/Assets/Scenes/PlayerMouseKeyboard/Camera Profile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 11d6b15f9bce75cd996cd3993ce49287
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Settings/Project Configuration/Quest Pro URP Config.asset
+++ b/Assets/Settings/Project Configuration/Quest Pro URP Config.asset
@@ -19,7 +19,7 @@ MonoBehaviour:
   m_RendererDataList:
   - {fileID: 11400000, guid: 53a413327819a984d8ab1618c9e90a10, type: 2}
   m_DefaultRendererIndex: 0
-  m_RequireDepthTexture: 0
+  m_RequireDepthTexture: 1
   m_RequireOpaqueTexture: 0
   m_OpaqueDownsampling: 1
   m_SupportsTerrainHoles: 0
@@ -83,9 +83,9 @@ MonoBehaviour:
     blueNoise64LTex: {fileID: 2800000, guid: e3d24661c1e055f45a7560c033dbb837, type: 3}
     bayerMatrixTex: {fileID: 2800000, guid: f9ee4ed84c1d10c49aabb9b210b0fc44, type: 3}
   m_PrefilteringModeMainLightShadows: 0
-  m_PrefilteringModeAdditionalLight: 4
+  m_PrefilteringModeAdditionalLight: 3
   m_PrefilteringModeAdditionalLightShadows: 0
-  m_PrefilterXRKeywords: 0
+  m_PrefilterXRKeywords: 1
   m_PrefilteringModeForwardPlus: 0
   m_PrefilteringModeDeferredRendering: 0
   m_PrefilteringModeScreenSpaceOcclusion: 0

--- a/Assets/Settings/Project Configuration/Quest Pro URP Renderer Data.asset
+++ b/Assets/Settings/Project Configuration/Quest Pro URP Renderer Data.asset
@@ -17,7 +17,8 @@ MonoBehaviour:
     hdrDebugViewPS: {fileID: 4800000, guid: 573620ae32aec764abd4d728906d2587, type: 3}
   m_RendererFeatures:
   - {fileID: 2959481156475367419}
-  m_RendererFeatureMap: fb2f2d8b6e301229
+  - {fileID: 9064544369461642386}
+  m_RendererFeatureMap: fb2f2d8b6e301229924487f813bbcb7d
   m_UseNativeRenderPass: 0
   postProcessData: {fileID: 11400000, guid: 41439944d30ece34e96484bdb6645b55, type: 2}
   xrSystemData: {fileID: 11400000, guid: 60e1133243b97e347b653163a8c01b64, type: 2}
@@ -91,3 +92,16 @@ MonoBehaviour:
   - {fileID: 2800000, guid: 3302065f671a8450b82c9ddf07426f3a, type: 3}
   - {fileID: 2800000, guid: 56a77a3e8d64f47b6afe9e3c95cb57d5, type: 3}
   m_Shader: {fileID: 4800000, guid: 0849e84e3d62649e8882e9d6f056a017, type: 3}
+--- !u!114 &9064544369461642386
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1778b560afb13c5449aadc62983479fb, type: 3}
+  m_Name: AmplifyOcclusionRenderer
+  m_EditorClassIdentifier: 
+  m_Active: 1

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -7,6 +7,7 @@
     "com.unity.ide.visualstudio": "2.0.21",
     "com.unity.learn.iet-framework": "3.1.3",
     "com.unity.mobile.android-logcat": "1.3.2",
+    "com.unity.postprocessing": "3.2.2",
     "com.unity.render-pipelines.universal": "14.0.8",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.7.5",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -110,6 +110,15 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.postprocessing": {
+      "version": "3.2.2",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.modules.physics": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.render-pipelines.core": {
       "version": "14.0.8",
       "depth": 1,


### PR DESCRIPTION
This adds an ambient occlusion effect.

Unity's default URP ambient occlusion isn't great. Therefore, I included a third party effect.

License: MIT
Original effect: https://github.com/AmplifyCreations/AmplifyOcclusion
URP port: https://github.com/neon-age/AmplifyOcclusion-URP

![ao](https://github.com/0mdc/siro_hitl_unity_client/assets/110583667/1589d2df-a75b-4c4a-ab83-cf356b8edc8b)