### PR TITLE
Gfx-replay and viewport fixes.

### DIFF
--- a/Assets/Scripts/GfxReplayPlayer.cs
+++ b/Assets/Scripts/GfxReplayPlayer.cs
@@ -230,6 +230,30 @@ public class GfxReplayPlayer : IUpdatable
             }
         }
 
+        // Handle Deletions
+        if (keyframe.deletions != null)
+        {
+            foreach (var key in keyframe.deletions)
+            {
+                if (_instanceDictionary.TryGetValue(key, out GfxReplayInstance instance))
+                {
+                    if (instance.rigId != Constants.ID_UNDEFINED)
+                    {
+                        _skinnedMeshes.Remove(instance.rigId);
+                    }
+
+                    if (_objectIdToInstanceKey.ContainsKey(instance.objectId))
+                    {
+                        _objectIdToInstanceKey.Remove(instance.objectId);
+                    }
+
+                    _instanceDictionary[key].Destroy();
+                    _instanceDictionary.Remove(key);
+                }
+            }
+            _coroutines.StartCoroutine(ReleaseUnusedMemory());
+        }
+
         if (keyframe.metadata != null)
         {
             foreach (var metadata in keyframe.metadata)
@@ -269,30 +293,6 @@ public class GfxReplayPlayer : IUpdatable
         }
 
         ProcessStateUpdates(keyframe);
-
-        // Handle Deletions
-        if (keyframe.deletions != null)
-        {
-            foreach (var key in keyframe.deletions)
-            {
-                if (_instanceDictionary.TryGetValue(key, out GfxReplayInstance instance))
-                {
-                    if (instance.rigId != Constants.ID_UNDEFINED)
-                    {
-                        _skinnedMeshes.Remove(instance.rigId);
-                    }
-
-                    if (_objectIdToInstanceKey.ContainsKey(instance.objectId))
-                    {
-                        _objectIdToInstanceKey.Remove(instance.objectId);
-                    }
-
-                    _instanceDictionary[key].Destroy();
-                    _instanceDictionary.Remove(key);
-                }
-            }
-            _coroutines.StartCoroutine(ReleaseUnusedMemory());
-        }
 
         // Process object properties.
         if (keyframe.message?.objects != null)

--- a/Assets/Scripts/ViewportHandler.cs
+++ b/Assets/Scripts/ViewportHandler.cs
@@ -23,7 +23,7 @@ public class ViewportHandler : IKeyframeMessageConsumer
     public const int LAYER_COUNT = 8;
     public const int LAST_LAYER_INDEX = FIRST_LAYER_INDEX + LAYER_COUNT;
 
-    int DEFAULT_LAYERS = LayerMask.NameToLayer("Default") | LayerMask.NameToLayer("UI");
+    int DEFAULT_LAYERS = LayerMask.GetMask("Default");
 
     public ViewportHandler(Camera mainCamera)
     {


### PR DESCRIPTION
This changeset fixes the following:

* Process deletion before updating components. This fixes update issues related to consolidated keyframes.
    * Notably, object metadata could be incorrectly attributed to an old instance, causing visbility issues.
* Fix main camera viewport layers.